### PR TITLE
Pass variables to MVT renderer

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     }
   ],
   "dependencies": {
-    "mapnik-vector-tile": "~1.2.2",
+    "mapnik-vector-tile": "cartodb/mapnik-vector-tile#1.2.2-pass-variables",
     "nan": "~2.4.0",
     "node-pre-gyp": "~0.6.30",
     "protozero": "~1.4.2"

--- a/src/mapnik_map.cpp
+++ b/src/mapnik_map.cpp
@@ -2090,7 +2090,7 @@ void Map::EIO_RenderVectorTile(uv_work_t* req)
     {
         mapnik::Map const& map = *closure->m->get();
 
-        mapnik::vector_tile_impl::processor ren(map);
+        mapnik::vector_tile_impl::processor ren(map, closure->variables);
         ren.set_simplify_distance(closure->simplify_distance);
         ren.set_multi_polygon_union(closure->multi_polygon_union);
         ren.set_fill_type(closure->fill_type);


### PR DESCRIPTION
Similar to what's done in https://github.com/CartoDB/node-mapnik/commit/7888167b56ba6ab0e765957741dd96ebf3031efe , and on top of https://github.com/CartoDB/mapnik-vector-tile/pull/1 , pass the variables to the vector tile processor so that they can be used later on to replace tokens in queries.

@Algunenano and @javisantana can you please take a look?