### PR TITLE
Fix submodule not being included

### DIFF
--- a/CHANGELOG.carto.md
+++ b/CHANGELOG.carto.md
@@ -1,5 +1,12 @@
 # CARTO node-mapnik changelog
 
+## 3.6.2-carto.2
+
+**Release date**: 2018-XX-XX
+
+Changes:
+ - Make sure the submodules are included
+
 ## 3.6.2-carto.1
 
 **Release date**: 2018-01-05

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ deps/geometry/include/mapbox/geometry.hpp:
 node_modules:
 	npm install --ignore-scripts --clang
 
-mason_packages/.link/bin/mapnik-config:
+mason_packages/.link/bin/mapnik-config: deps/geometry/include/mapbox/geometry.hpp
 	./install_mason.sh
 
 pre_build_check:


### PR DESCRIPTION
Seems I removed it with the cherry-pick so building the npm package from source it's currently impossible:
```
../../../mapnik-vector-tile/src/vector_tile_geometry_clipper.hpp:10:10: fatal error: mapbox/geometry/geometry.hpp: No such file or directory
```