### PR TITLE
Allow dynamic builds from the top

### DIFF
--- a/CHANGELOG.carto.md
+++ b/CHANGELOG.carto.md
@@ -1,5 +1,14 @@
 # CARTO node-mapnik changelog
 
+## 3.6.2-carto.5
+
+**Release date**: 2018-XX-XX
+
+Changes:
+ - [Upstream] move to prepublishOnly
+ - [Upstream] Add mapnik-index command in 'bin' so it gets installed by npm
+ - Allow switching the default build with an environment variable
+
 ## 3.6.2-carto.4
 
 **Release date**: 2018-03-14

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 MODULE_NAME := $(shell node -e "console.log(require('./package.json').binary.module_name)")
 
-default: release
+NODE_MAPNIK_BUILD ?= release
+
+default: $(NODE_MAPNIK_BUILD)
 
 deps/geometry/include/mapbox/geometry.hpp:
 	git submodule update --init

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "node-pre-gyp"
   ],
   "bin": {
+    "mapnik-index.js": "./bin/mapnik-index.js",
     "mapnik-inspect.js": "./bin/mapnik-inspect.js",
     "mapnik-render.js": "./bin/mapnik-render.js",
     "mapnik-shapeindex.js": "./bin/mapnik-shapeindex.js"

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "mapnik-shapeindex.js": "./bin/mapnik-shapeindex.js"
   },
   "scripts": {
-    "prepublish": "npm ls",
+    "prepublishOnly": "npm ls",
     "test": "jshint bin lib/index.js lib/mapnik.js && mocha -R spec --timeout 50000",
     "install": "node-pre-gyp install --fallback-to-build",
     "docs": "documentation build src/*.cpp src/mapnik_plugins.hpp --polyglot -o documentation -f html --github --name Mapnik"


### PR DESCRIPTION
The idea is to be able to produce a dynamic node-mapnik module that links with the local installation directly from the `npm` call or even switch to a debug build:
```bash
[raul tilelive-mapnik]$ rm -rf node_modules/ package-lock.json
[raul tilelive-mapnik]$ MAKEFLAGS=-j11 CXX=clang++ CC=clang NODE_MAPNIK_BUILD=release_base npm install --build-from-source
[...]
[raul tilelive-mapnik]$ ldd node_modules/@carto/mapnik/lib/binding/mapnik.node 
        linux-vdso.so.1 (0x00007fffe0f8d000)
        libmapnik.so.3.0 => /usr/lib/libmapnik.so.3.0 (0x00007f6307710000)
        libboost_filesystem.so.1.66.0 => /usr/lib/libboost_filesystem.so.1.66.0 (0x00007f63074f5000)
        libboost_regex.so.1.66.0 => /usr/lib/libboost_regex.so.1.66.0 (0x00007f63071e7000)
        libcairo.so.2 => /usr/lib/libcairo.so.2 (0x00007f6306ec5000)
        libpng16.so.16 => /usr/lib/libpng16.so.16 (0x00007f6306c8f000)
        libproj.so.12 => /usr/lib/libproj.so.12 (0x00007f6306a25000)
        libtiff.so.5 => /usr/lib/libtiff.so.5 (0x00007f630679d000)
        libwebp.so.7 => /usr/lib/libwebp.so.7 (0x00007f6306533000)
        libxml2.so.2 => /usr/lib/libxml2.so.2 (0x00007f63061cd000)
        libicui18n.so.60 => /usr/lib/libicui18n.so.60 (0x00007f6305d2a000)
        libboost_system.so.1.66.0 => /usr/lib/libboost_system.so.1.66.0 (0x00007f6305b25000)
        libharfbuzz.so.0 => /usr/lib/libharfbuzz.so.0 (0x00007f6305873000)
        libjpeg.so.8 => /usr/lib/libjpeg.so.8 (0x00007f630560b000)
        libicuuc.so.60 => /usr/lib/libicuuc.so.60 (0x00007f6305252000)
        libfreetype.so.6 => /usr/lib/libfreetype.so.6 (0x00007f6304f89000)
        libz.so.1 => /usr/lib/libz.so.1 (0x00007f6304d72000)
        libdl.so.2 => /usr/lib/libdl.so.2 (0x00007f6304b6e000)
        libstdc++.so.6 => /usr/lib/libstdc++.so.6 (0x00007f63047e7000)
        libm.so.6 => /usr/lib/libm.so.6 (0x00007f630449b000)
        libgcc_s.so.1 => /usr/lib/libgcc_s.so.1 (0x00007f6304284000)
        libpthread.so.0 => /usr/lib/libpthread.so.0 (0x00007f6304066000)
        libc.so.6 => /usr/lib/libc.so.6 (0x00007f6303caf000)
        /usr/lib64/ld-linux-x86-64.so.2 (0x00007f6308878000)
        librt.so.1 => /usr/lib/librt.so.1 (0x00007f6303aa7000)
        libicudata.so.60 => /usr/lib/libicudata.so.60 (0x00007f6301eff000)
        libpixman-1.so.0 => /usr/lib/libpixman-1.so.0 (0x00007f6301c57000)
        libfontconfig.so.1 => /usr/lib/libfontconfig.so.1 (0x00007f6301a12000)
        libxcb-shm.so.0 => /usr/lib/libxcb-shm.so.0 (0x00007f630180e000)
        libxcb.so.1 => /usr/lib/libxcb.so.1 (0x00007f63015e5000)
        libxcb-render.so.0 => /usr/lib/libxcb-render.so.0 (0x00007f63013d7000)
        libXrender.so.1 => /usr/lib/libXrender.so.1 (0x00007f63011cc000)
        libX11.so.6 => /usr/lib/libX11.so.6 (0x00007f6300e8d000)
        libXext.so.6 => /usr/lib/libXext.so.6 (0x00007f6300c7b000)
        liblzma.so.5 => /usr/lib/liblzma.so.5 (0x00007f6300a55000)
        libglib-2.0.so.0 => /usr/lib/libglib-2.0.so.0 (0x00007f6300740000)
        libgraphite2.so.3 => /usr/lib/libgraphite2.so.3 (0x00007f6300514000)
        libbz2.so.1.0 => /usr/lib/libbz2.so.1.0 (0x00007f6300304000)
        libexpat.so.1 => /usr/lib/libexpat.so.1 (0x00007f63000d2000)
        libXau.so.6 => /usr/lib/libXau.so.6 (0x00007f62ffece000)
        libXdmcp.so.6 => /usr/lib/libXdmcp.so.6 (0x00007f62ffcc8000)
        libpcre.so.1 => /usr/lib/libpcre.so.1 (0x00007f62ffa55000)
added 131 packages from 374 contributors in 55.486s
```

Or with debug:
```
MAKEFLAGS=-j11 CXX=clang++ CC=clang NODE_MAPNIK_BUILD=debug_base npm install --build-from-source
```

And without it (default to `release` which will use the static build from AWS if available):
```bash
[raul tilelive-mapnik]$ rm -rf node_modules/ package-lock.json
[raul tilelive-mapnik]$ npm install
npm WARN deprecated sphericalmercator@1.0.5: This module is now under the @mapbox namespace: install @mapbox/sphericalmercator instead
npm WARN deprecated protozero@1.5.1: protozero should no longer be used via npm, install instead via https://github.com/mapbox/mason

> @carto/mapnik@3.6.2-carto.4 install /home/raul/dev/public/tilelive-mapnik/node_modules/@carto/mapnik
> node-pre-gyp install --fallback-to-build

[@carto/mapnik] Success: "/home/raul/dev/public/tilelive-mapnik/node_modules/@carto/mapnik/lib/binding/mapnik.node" is installed via remote
npm notice created a lockfile as package-lock.json. You should commit this file.
npm WARN tilelive-mapnik@0.6.18-cdb8 No license field.

added 131 packages from 374 contributors in 12.029s
[raul tilelive-mapnik]$ ldd node_modules/@carto/mapnik/lib/binding/mapnik.node 
        linux-vdso.so.1 (0x00007ffe45341000)
        libmapnik.so => /home/raul/dev/public/tilelive-mapnik/node_modules/@carto/mapnik/lib/binding/lib/libmapnik.so (0x00007f674e740000)
        libz.so.1 => /usr/lib/libz.so.1 (0x00007f674e529000)
        libdl.so.2 => /usr/lib/libdl.so.2 (0x00007f674e325000)
        libstdc++.so.6 => /usr/lib/libstdc++.so.6 (0x00007f674df9e000)
        libm.so.6 => /usr/lib/libm.so.6 (0x00007f674dc52000)
        libgcc_s.so.1 => /usr/lib/libgcc_s.so.1 (0x00007f674da3b000)
        libpthread.so.0 => /usr/lib/libpthread.so.0 (0x00007f674d81d000)
        libc.so.6 => /usr/lib/libc.so.6 (0x00007f674d466000)
        /usr/lib64/ld-linux-x86-64.so.2 (0x00007f674fe69000)
```

Also I've brought a couple of fixes from upstream:
* Switch to prepublishOnly (which shuts up warning in npm5)
* Includes `mapnik-index` in the bin files for npm.