### PR TITLE
Protozero submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "deps/geometry"]
 	path = deps/geometry
 	url = https://github.com/mapbox/geometry.hpp.git
+[submodule "deps/protozero"]
+	path = deps/protozero
+	url = https://github.com/mapbox/protozero.git

--- a/CHANGELOG.carto.md
+++ b/CHANGELOG.carto.md
@@ -1,5 +1,12 @@
 # CARTO node-mapnik changelog
 
+## 3.6.2-carto.11
+
+**Release date**: 2018-XX-XX
+
+Changes:
+ - Use protozero from submodule instead of the deprecated npm module.
+
 ## 3.6.2-carto.10
 
 **Release date**: 2018-05-14

--- a/binding.gyp
+++ b/binding.gyp
@@ -62,8 +62,8 @@
         # TODO: move these to mason packages once we have a minimal windows client for mason (@springmeyer)
         # https://github.com/mapbox/mason/issues/396
         "./deps/geometry/include/",
+        "./deps/protozero/include/",
         "./deps/wagyu/include/",
-        "<!(node -e \"require('protozero')\")",
         "<!(node -e \"require('mapnik-vector-tile')\")"
       ],
       'defines': [

--- a/package.json
+++ b/package.json
@@ -37,8 +37,7 @@
   "dependencies": {
     "mapnik-vector-tile": "cartodb/mapnik-vector-tile#v1.6.1-carto.1",
     "nan": "2.10.0",
-    "node-pre-gyp": "0.10.0",
-    "protozero": "1.5.1"
+    "node-pre-gyp": "0.10.0"
   },
   "bundledDependencies": [
     "node-pre-gyp"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "url": "http://github.com/mapnik/node-mapnik",
   "homepage": "http://mapnik.org",
   "author": "Dane Springmeyer <dane@mapbox.com> (mapnik.org)",
-  "version": "3.6.2-carto.10",
+  "version": "3.6.2-carto.11",
   "mapnik_version": "v3.0.15.9",
   "main": "./lib/mapnik.js",
   "binary": {


### PR DESCRIPTION
Closes #16 

It's the same code but uses the recommended way (submodule) instead of the deprecated npm module. It updates the release from 1.5.1 (last release in npm) to 1.6.3. I'll check performance as part of MVT changes.
 
Packaging should be covered since we are including all submodules (init && sync && update).