### PR TITLE
Dev dependencies

### DIFF
--- a/CHANGELOG.carto.md
+++ b/CHANGELOG.carto.md
@@ -6,6 +6,12 @@
 
 Changes:
  - Use protozero from submodule instead of the deprecated npm module.
+ - Update development dependencies:
+    - Remove "node-gyp" as it's no longer needed (no node 0.10 support).
+    - "jshint": "^2.5.10" -> "2.9.5"
+    - "mocha": "2.x" -> "5.2.0"
+    - ""@mapbox/sphericalmercator": "~1.0.2" -> "1.0.5"
+    - "bytes": "~2.1.0" -> "3.0.0"
 
 ## 3.6.2-carto.10
 

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "aws-sdk": "2.0.12",
     "jshint": "2.9.5",
     "mocha": "5.2.0",
-    "@mapbox/sphericalmercator": "~1.0.2",
+    "@mapbox/sphericalmercator": "1.0.5",
     "bytes": "3.0.0"
   },
   "jshintConfig": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   },
   "devDependencies": {
     "aws-sdk": "2.0.12",
-    "jshint": "^2.5.10",
+    "jshint": "2.9.5",
     "mocha": "2.x",
     "@mapbox/sphericalmercator": "~1.0.2",
     "bytes": "~2.1.0"

--- a/package.json
+++ b/package.json
@@ -47,14 +47,14 @@
   },
   "scripts": {
     "prepublishOnly": "npm ls",
-    "test": "jshint bin lib/index.js lib/mapnik.js && mocha -R spec --timeout 50000",
+    "test": "jshint bin lib/index.js lib/mapnik.js && mocha --exit -R spec --timeout 50000",
     "install": "node-pre-gyp install --fallback-to-build",
     "docs": "documentation build src/*.cpp src/mapnik_plugins.hpp --polyglot -o documentation -f html --github --name Mapnik"
   },
   "devDependencies": {
     "aws-sdk": "2.0.12",
     "jshint": "2.9.5",
-    "mocha": "2.x",
+    "mocha": "5.2.0",
     "@mapbox/sphericalmercator": "~1.0.2",
     "bytes": "~2.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "docs": "documentation build src/*.cpp src/mapnik_plugins.hpp --polyglot -o documentation -f html --github --name Mapnik"
   },
   "devDependencies": {
-    "node-gyp": "^3.6.1",
     "aws-sdk": "2.0.12",
     "jshint": "^2.5.10",
     "mocha": "2.x",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "jshint": "2.9.5",
     "mocha": "5.2.0",
     "@mapbox/sphericalmercator": "~1.0.2",
-    "bytes": "~2.1.0"
+    "bytes": "3.0.0"
   },
   "jshintConfig": {
     "node": true,

--- a/package.json
+++ b/package.json
@@ -39,9 +39,6 @@
     "nan": "2.10.0",
     "node-pre-gyp": "0.10.0"
   },
-  "bundledDependencies": [
-    "node-pre-gyp"
-  ],
   "bin": {
     "mapnik-index.js": "./bin/mapnik-index.js",
     "mapnik-inspect.js": "./bin/mapnik-inspect.js",


### PR DESCRIPTION
Closes https://github.com/CartoDB/node-mapnik/issues/17

There is still a minor security report pending but there isn't a jshint released with the fix. All of these are development dependencies so no impact to performance.

I've decided to maintain the awk module as it is because it works and doesn't have any known vulnerability (and I don't have an easy way to test it).