### PR TITLE
 Leaks

### DIFF
--- a/CHANGELOG.carto.md
+++ b/CHANGELOG.carto.md
@@ -1,5 +1,14 @@
 # CARTO node-mapnik changelog
 
+## 3.6.2-carto.16
+
+**Release date**: 2019-XX-XX
+
+Changes:
+ - Silence GCC warnings around uv_after_work_cb functions.
+ - Tests: Avoid Buffer() constructor.
+ - Avoid dangling references when an error happenned before an async task.
+
 ## 3.6.2-carto.15
 
 **Release date**: 2019-05-20

--- a/CHANGELOG.carto.md
+++ b/CHANGELOG.carto.md
@@ -8,6 +8,7 @@ Changes:
  - Silence GCC warnings around uv_after_work_cb functions.
  - Tests: Avoid Buffer() constructor.
  - Avoid dangling references when an error happenned before an async task.
+ - mapnik_image: Avoid throwing in callbacks as it leaks resources.
 
 ## 3.6.2-carto.15
 

--- a/src/blend.cpp
+++ b/src/blend.cpp
@@ -418,7 +418,7 @@ void Work_Blend(uv_work_t* req)
     Blend_Encode(target, baton, alpha);
 }
 
-void Work_AfterBlend(uv_work_t* req) {
+void EIO_AfterBlend(uv_work_t* req, int) {
     Nan::HandleScope scope;
     BlendBaton* baton = static_cast<BlendBaton*>(req->data);
 	Nan::AsyncResource async_resource(__func__);
@@ -674,7 +674,7 @@ NAN_METHOD(Blend) {
         baton->images.push_back(image);
     }
 
-    uv_queue_work(uv_default_loop(), &(baton.release())->request, Work_Blend, (uv_after_work_cb)Work_AfterBlend);
+    uv_queue_work(uv_default_loop(), &(baton.release())->request, Work_Blend, (uv_after_work_cb)EIO_AfterBlend);
 
     return;
 }

--- a/src/blend.hpp
+++ b/src/blend.hpp
@@ -4,6 +4,7 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wshadow"
+#pragma GCC diagnostic ignored "-Wcast-function-type"
 #include <nan.h>
 #pragma GCC diagnostic pop
 

--- a/src/ds_emitter.hpp
+++ b/src/ds_emitter.hpp
@@ -5,6 +5,7 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wshadow"
+#pragma GCC diagnostic ignored "-Wcast-function-type"
 #include <nan.h>
 #pragma GCC diagnostic pop
 

--- a/src/mapnik_cairo_surface.hpp
+++ b/src/mapnik_cairo_surface.hpp
@@ -4,6 +4,7 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wshadow"
+#pragma GCC diagnostic ignored "-Wcast-function-type"
 #include <nan.h>
 #pragma GCC diagnostic pop
 

--- a/src/mapnik_color.hpp
+++ b/src/mapnik_color.hpp
@@ -4,6 +4,7 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wshadow"
+#pragma GCC diagnostic ignored "-Wcast-function-type"
 #include <nan.h>
 #pragma GCC diagnostic pop
 

--- a/src/mapnik_datasource.hpp
+++ b/src/mapnik_datasource.hpp
@@ -4,6 +4,7 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wshadow"
+#pragma GCC diagnostic ignored "-Wcast-function-type"
 #include <nan.h>
 #pragma GCC diagnostic pop
 

--- a/src/mapnik_expression.hpp
+++ b/src/mapnik_expression.hpp
@@ -4,6 +4,7 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wshadow"
+#pragma GCC diagnostic ignored "-Wcast-function-type"
 #include <nan.h>
 #pragma GCC diagnostic pop
 

--- a/src/mapnik_feature.hpp
+++ b/src/mapnik_feature.hpp
@@ -4,6 +4,7 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wshadow"
+#pragma GCC diagnostic ignored "-Wcast-function-type"
 #include <nan.h>
 #pragma GCC diagnostic pop
 

--- a/src/mapnik_featureset.hpp
+++ b/src/mapnik_featureset.hpp
@@ -4,6 +4,7 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wshadow"
+#pragma GCC diagnostic ignored "-Wcast-function-type"
 #include <nan.h>
 #pragma GCC diagnostic pop
 

--- a/src/mapnik_geometry.cpp
+++ b/src/mapnik_geometry.cpp
@@ -244,7 +244,7 @@ NAN_METHOD(Geometry::toJSON)
     }
     v8::Local<v8::Value> callback = info[info.Length()-1];
     closure->cb.Reset(callback.As<v8::Function>());
-    uv_queue_work(uv_default_loop(), &closure->request, to_json, (uv_after_work_cb)after_to_json);
+    uv_queue_work(uv_default_loop(), &closure->request, to_json, (uv_after_work_cb)EIO_After_to_json);
     closure->g->Ref();
     return;
 }
@@ -292,7 +292,7 @@ void Geometry::to_json(uv_work_t* req)
     }
 }
 
-void Geometry::after_to_json(uv_work_t* req)
+void Geometry::EIO_After_to_json(uv_work_t* req, int)
 {
     Nan::HandleScope scope;
     to_json_baton *closure = static_cast<to_json_baton *>(req->data);

--- a/src/mapnik_geometry.cpp
+++ b/src/mapnik_geometry.cpp
@@ -245,7 +245,7 @@ NAN_METHOD(Geometry::toJSON)
     v8::Local<v8::Value> callback = info[info.Length()-1];
     closure->cb.Reset(callback.As<v8::Function>());
     uv_queue_work(uv_default_loop(), &closure->request, to_json, (uv_after_work_cb)EIO_After_to_json);
-    closure->g->Ref();
+    closure->g->_ref();
     return;
 }
 
@@ -311,7 +311,7 @@ void Geometry::EIO_After_to_json(uv_work_t* req, int)
         v8::Local<v8::Value> argv[2] = { Nan::Null(), Nan::New<v8::String>(closure->result).ToLocalChecked() };
         async_resource.runInAsyncScope(Nan::GetCurrentContext()->Global(), Nan::New(closure->cb), 2, argv);
     }
-    closure->g->Unref();
+    closure->g->_unref();
     if (closure->tr) {
         closure->tr->_unref();
     }

--- a/src/mapnik_geometry.hpp
+++ b/src/mapnik_geometry.hpp
@@ -29,6 +29,9 @@ public:
     static void to_json(uv_work_t* req);
     static void EIO_After_to_json(uv_work_t* req, int);
     Geometry(mapnik::feature_ptr f);
+
+    void _ref() { Ref(); }
+    void _unref() { Unref(); }
 private:
     ~Geometry();
     mapnik::feature_ptr feat_;

--- a/src/mapnik_geometry.hpp
+++ b/src/mapnik_geometry.hpp
@@ -4,6 +4,7 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wshadow"
+#pragma GCC diagnostic ignored "-Wcast-function-type"
 #include <nan.h>
 #pragma GCC diagnostic pop
 
@@ -26,7 +27,7 @@ public:
     static NAN_METHOD(toJSON);
     static NAN_METHOD(toJSONSync);
     static void to_json(uv_work_t* req);
-    static void after_to_json(uv_work_t* req);
+    static void EIO_After_to_json(uv_work_t* req, int);
     Geometry(mapnik::feature_ptr f);
 private:
     ~Geometry();

--- a/src/mapnik_grid.cpp
+++ b/src/mapnik_grid.cpp
@@ -162,7 +162,7 @@ NAN_METHOD(Grid::clear)
     closure->error = false;
     closure->cb.Reset(callback.As<v8::Function>());
     uv_queue_work(uv_default_loop(), &closure->request, EIO_Clear, (uv_after_work_cb)EIO_AfterClear);
-    g->Ref();
+    g->_ref();
     return;
 }
 
@@ -204,7 +204,7 @@ void Grid::EIO_AfterClear(uv_work_t* req, int)
         v8::Local<v8::Value> argv[2] = { Nan::Null(), closure->g->handle() };
         async_resource.runInAsyncScope(Nan::GetCurrentContext()->Global(), Nan::New(closure->cb), 2, argv);
     }
-    closure->g->Unref();
+    closure->g->_unref();
     closure->cb.Reset();
     delete closure;
 }
@@ -522,7 +522,7 @@ NAN_METHOD(Grid::encode)
     closure->cb.Reset(callback.As<v8::Function>());
     // todo - reserve lines size?
     uv_queue_work(uv_default_loop(), &closure->request, EIO_Encode, (uv_after_work_cb)EIO_AfterEncode);
-    g->Ref();
+    g->_ref();
     return;
 }
 
@@ -602,7 +602,7 @@ void Grid::EIO_AfterEncode(uv_work_t* req, int)
         async_resource.runInAsyncScope(Nan::GetCurrentContext()->Global(), Nan::New(closure->cb), 2, argv);
     }
 
-    closure->g->Unref();
+    closure->g->_unref();
     closure->cb.Reset();
     delete closure;
 }

--- a/src/mapnik_grid.cpp
+++ b/src/mapnik_grid.cpp
@@ -184,7 +184,7 @@ void Grid::EIO_Clear(uv_work_t* req)
     }
 }
 
-void Grid::EIO_AfterClear(uv_work_t* req)
+void Grid::EIO_AfterClear(uv_work_t* req, int)
 {
     Nan::HandleScope scope;
 	Nan::AsyncResource async_resource(__func__);
@@ -548,7 +548,7 @@ void Grid::EIO_Encode(uv_work_t* req)
     }
 }
 
-void Grid::EIO_AfterEncode(uv_work_t* req)
+void Grid::EIO_AfterEncode(uv_work_t* req, int)
 {
     Nan::HandleScope scope;
 	Nan::AsyncResource async_resource(__func__);

--- a/src/mapnik_grid.hpp
+++ b/src/mapnik_grid.hpp
@@ -6,6 +6,7 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wshadow"
+#pragma GCC diagnostic ignored "-Wcast-function-type"
 #include <nan.h>
 #pragma GCC diagnostic pop
 
@@ -25,7 +26,7 @@ public:
     static NAN_METHOD(encodeSync);
     static NAN_METHOD(encode);
     static void EIO_Encode(uv_work_t* req);
-    static void EIO_AfterEncode(uv_work_t* req);
+    static void EIO_AfterEncode(uv_work_t* req, int);
 
     static NAN_METHOD(addField);
     static NAN_METHOD(fields);
@@ -37,7 +38,7 @@ public:
     static NAN_METHOD(clearSync);
     static NAN_METHOD(clear);
     static void EIO_Clear(uv_work_t* req);
-    static void EIO_AfterClear(uv_work_t* req);
+    static void EIO_AfterClear(uv_work_t* req, int);
 
     static NAN_GETTER(get_key);
     static NAN_SETTER(set_key);

--- a/src/mapnik_grid_view.cpp
+++ b/src/mapnik_grid_view.cpp
@@ -183,7 +183,7 @@ void GridView::EIO_IsSolid(uv_work_t* req)
     }
 }
 
-void GridView::EIO_AfterIsSolid(uv_work_t* req)
+void GridView::EIO_AfterIsSolid(uv_work_t* req, int)
 {
     Nan::HandleScope scope;
 	Nan::AsyncResource async_resource(__func__);
@@ -482,7 +482,7 @@ void GridView::EIO_Encode(uv_work_t* req)
     }
 }
 
-void GridView::EIO_AfterEncode(uv_work_t* req)
+void GridView::EIO_AfterEncode(uv_work_t* req, int)
 {
     Nan::HandleScope scope;
 	Nan::AsyncResource async_resource(__func__);

--- a/src/mapnik_grid_view.cpp
+++ b/src/mapnik_grid_view.cpp
@@ -152,7 +152,7 @@ NAN_METHOD(GridView::isSolid)
     closure->error = false;
     closure->cb.Reset(callback.As<v8::Function>());
     uv_queue_work(uv_default_loop(), &closure->request, EIO_IsSolid, (uv_after_work_cb)EIO_AfterIsSolid);
-    g->Ref();
+    g->_ref();
     return;
 }
 void GridView::EIO_IsSolid(uv_work_t* req)
@@ -210,7 +210,7 @@ void GridView::EIO_AfterIsSolid(uv_work_t* req, int)
             async_resource.runInAsyncScope(Nan::GetCurrentContext()->Global(), Nan::New(closure->cb), 2, argv);
         }
     }
-    closure->g->Unref();
+    closure->g->_unref();
     closure->cb.Reset();
     delete closure;
 }
@@ -455,7 +455,7 @@ NAN_METHOD(GridView::encode)
     closure->add_features = add_features;
     closure->cb.Reset(callback);
     uv_queue_work(uv_default_loop(), &closure->request, EIO_Encode, (uv_after_work_cb)EIO_AfterEncode);
-    g->Ref();
+    g->_ref();
     return;
 }
 
@@ -534,7 +534,7 @@ void GridView::EIO_AfterEncode(uv_work_t* req, int)
         async_resource.runInAsyncScope(Nan::GetCurrentContext()->Global(), Nan::New(closure->cb), 2, argv);
     }
 
-    closure->g->Unref();
+    closure->g->_unref();
     closure->cb.Reset();
     delete closure;
 }

--- a/src/mapnik_grid_view.hpp
+++ b/src/mapnik_grid_view.hpp
@@ -6,6 +6,7 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wshadow"
+#pragma GCC diagnostic ignored "-Wcast-function-type"
 #include <nan.h>
 #pragma GCC diagnostic pop
 
@@ -29,13 +30,13 @@ public:
     static NAN_METHOD(encode);
     static NAN_METHOD(fields);
     static void EIO_Encode(uv_work_t* req);
-    static void EIO_AfterEncode(uv_work_t* req);
+    static void EIO_AfterEncode(uv_work_t* req, int);
 
     static NAN_METHOD(width);
     static NAN_METHOD(height);
     static NAN_METHOD(isSolid);
     static void EIO_IsSolid(uv_work_t* req);
-    static void EIO_AfterIsSolid(uv_work_t* req);
+    static void EIO_AfterIsSolid(uv_work_t* req, int);
     static v8::Local<v8::Value> _isSolidSync(Nan::NAN_METHOD_ARGS_TYPE info);
     static NAN_METHOD(isSolidSync);
     static NAN_METHOD(getPixel);

--- a/src/mapnik_grid_view.hpp
+++ b/src/mapnik_grid_view.hpp
@@ -44,6 +44,9 @@ public:
     GridView(Grid * JSGrid);
     inline grid_view_ptr get() { return this_; }
 
+    void _ref() { Ref(); }
+    void _unref() { Unref(); }
+
 private:
     ~GridView();
     grid_view_ptr this_;

--- a/src/mapnik_image.cpp
+++ b/src/mapnik_image.cpp
@@ -751,7 +751,7 @@ NAN_METHOD(Image::filter)
     closure->error = false;
     closure->cb.Reset(callback.As<v8::Function>());
     uv_queue_work(uv_default_loop(), &closure->request, EIO_Filter, (uv_after_work_cb)EIO_AfterFilter);
-    im->Ref();
+    im->_ref();
     return;
 }
 
@@ -784,7 +784,7 @@ void Image::EIO_AfterFilter(uv_work_t* req, int)
         v8::Local<v8::Value> argv[2] = { Nan::Null(), closure->im->handle() };
         async_resource.runInAsyncScope(Nan::GetCurrentContext()->Global(), Nan::New(closure->cb), 2, argv);
     }
-    closure->im->Unref();
+    closure->im->_unref();
     closure->cb.Reset();
     delete closure;
 }
@@ -960,7 +960,7 @@ NAN_METHOD(Image::fill)
         closure->error = false;
         closure->cb.Reset(callback.As<v8::Function>());
         uv_queue_work(uv_default_loop(), &closure->request, EIO_Fill, (uv_after_work_cb)EIO_AfterFill);
-        im->Ref();
+        im->_ref();
     }
     return;
 }
@@ -1009,7 +1009,7 @@ void Image::EIO_AfterFill(uv_work_t* req, int)
         v8::Local<v8::Value> argv[2] = { Nan::Null(), closure->im->handle() };
         async_resource.runInAsyncScope(Nan::GetCurrentContext()->Global(), Nan::New(closure->cb), 2, argv);
     }
-    closure->im->Unref();
+    closure->im->_unref();
     closure->cb.Reset();
     delete closure;
 }
@@ -1090,7 +1090,7 @@ NAN_METHOD(Image::clear)
     closure->error = false;
     closure->cb.Reset(callback.As<v8::Function>());
     uv_queue_work(uv_default_loop(), &closure->request, EIO_Clear, (uv_after_work_cb)EIO_AfterClear);
-    im->Ref();
+    im->_ref();
     return;
 }
 
@@ -1123,7 +1123,7 @@ void Image::EIO_AfterClear(uv_work_t* req, int)
         v8::Local<v8::Value> argv[2] = { Nan::Null(), closure->im->handle() };
         async_resource.runInAsyncScope(Nan::GetCurrentContext()->Global(), Nan::New(closure->cb), 2, argv);
     }
-    closure->im->Unref();
+    closure->im->_unref();
     closure->cb.Reset();
     delete closure;
 }
@@ -1254,7 +1254,7 @@ NAN_METHOD(Image::premultiply)
     closure->im = im;
     closure->cb.Reset(callback.As<v8::Function>());
     uv_queue_work(uv_default_loop(), &closure->request, EIO_Premultiply, (uv_after_work_cb)EIO_AfterMultiply);
-    im->Ref();
+    im->_ref();
     return;
 }
 
@@ -1271,7 +1271,7 @@ void Image::EIO_AfterMultiply(uv_work_t* req, int)
     image_op_baton_t *closure = static_cast<image_op_baton_t *>(req->data);
     v8::Local<v8::Value> argv[2] = { Nan::Null(), closure->im->handle() };
     async_resource.runInAsyncScope(Nan::GetCurrentContext()->Global(), Nan::New(closure->cb), 2, argv);
-    closure->im->Unref();
+    closure->im->_unref();
     closure->cb.Reset();
     delete closure;
 }
@@ -1326,7 +1326,7 @@ NAN_METHOD(Image::demultiply)
     closure->im = im;
     closure->cb.Reset(callback.As<v8::Function>());
     uv_queue_work(uv_default_loop(), &closure->request, EIO_Demultiply, (uv_after_work_cb)EIO_AfterMultiply);
-    im->Ref();
+    im->_ref();
     return;
 }
 
@@ -1381,7 +1381,7 @@ NAN_METHOD(Image::isSolid)
     closure->error = false;
     closure->cb.Reset(callback.As<v8::Function>());
     uv_queue_work(uv_default_loop(), &closure->request, EIO_IsSolid, (uv_after_work_cb)EIO_AfterIsSolid);
-    im->Ref();
+    im->_ref();
     return;
 }
 
@@ -1424,7 +1424,7 @@ void Image::EIO_AfterIsSolid(uv_work_t* req, int)
             async_resource.runInAsyncScope(Nan::GetCurrentContext()->Global(), Nan::New(closure->cb), 2, argv);
         }
     }
-    closure->im->Unref();
+    closure->im->_unref();
     closure->cb.Reset();
     delete closure;
 }
@@ -1583,7 +1583,7 @@ NAN_METHOD(Image::copy)
     closure->error = false;
     closure->cb.Reset(callback.As<v8::Function>());
     uv_queue_work(uv_default_loop(), &closure->request, EIO_Copy, (uv_after_work_cb)EIO_AfterCopy);
-    closure->im1->Ref();
+    closure->im1->_ref();
     return;
 }
 
@@ -1634,7 +1634,7 @@ void Image::EIO_AfterCopy(uv_work_t* req, int)
         v8::Local<v8::Value> argv[2] = { Nan::Null(), maybe_local.ToLocalChecked() };
         async_resource.runInAsyncScope(Nan::GetCurrentContext()->Global(), Nan::New(closure->cb), 2, argv);
     }
-    closure->im1->Unref();
+    closure->im1->_unref();
     closure->cb.Reset();
     delete closure;
 }
@@ -1927,7 +1927,7 @@ NAN_METHOD(Image::resize)
     closure->error = false;
     closure->cb.Reset(callback.As<v8::Function>());
     uv_queue_work(uv_default_loop(), &closure->request, EIO_Resize, (uv_after_work_cb)EIO_AfterResize);
-    closure->im1->Ref();
+    closure->im1->_ref();
     return;
 }
 
@@ -2100,7 +2100,7 @@ void Image::EIO_AfterResize(uv_work_t* req, int)
         v8::Local<v8::Value> argv[2] = { Nan::Null(), maybe_local.ToLocalChecked() };
         async_resource.runInAsyncScope(Nan::GetCurrentContext()->Global(), Nan::New(closure->cb), 2, argv);
     }
-    closure->im1->Unref();
+    closure->im1->_unref();
     closure->cb.Reset();
     delete closure;
 }
@@ -3805,7 +3805,7 @@ NAN_METHOD(Image::encode)
     closure->error = false;
     closure->cb.Reset(callback.As<v8::Function>());
     uv_queue_work(uv_default_loop(), &closure->request, EIO_Encode, (uv_after_work_cb)EIO_AfterEncode);
-    im->Ref();
+    im->_ref();
 
     return;
 }
@@ -3848,7 +3848,7 @@ void Image::EIO_AfterEncode(uv_work_t* req, int)
         async_resource.runInAsyncScope(Nan::GetCurrentContext()->Global(), Nan::New(closure->cb), 2, argv);
     }
 
-    closure->im->Unref();
+    closure->im->_unref();
     closure->cb.Reset();
     delete closure;
 }
@@ -4015,7 +4015,7 @@ NAN_METHOD(Image::save)
     closure->error = false;
     closure->cb.Reset(callback.As<v8::Function>());
     uv_queue_work(uv_default_loop(), &closure->request, EIO_Save, (uv_after_work_cb)EIO_AfterSave);
-    im->Ref();
+    im->_ref();
     return;
 }
 
@@ -4050,7 +4050,7 @@ void Image::EIO_AfterSave(uv_work_t* req, int)
         v8::Local<v8::Value> argv[1] = { Nan::Null() };
         async_resource.runInAsyncScope(Nan::GetCurrentContext()->Global(), Nan::New(closure->cb), 1, argv);
     }
-    closure->im->Unref();
+    closure->im->_unref();
     closure->cb.Reset();
     delete closure;
 }
@@ -4235,8 +4235,8 @@ NAN_METHOD(Image::composite)
     closure->error = false;
     closure->cb.Reset(callback.As<v8::Function>());
     uv_queue_work(uv_default_loop(), &closure->request, EIO_Composite, (uv_after_work_cb)EIO_AfterComposite);
-    closure->im1->Ref();
-    closure->im2->Ref();
+    closure->im1->_ref();
+    closure->im2->_ref();
     return;
 }
 
@@ -4281,8 +4281,8 @@ void Image::EIO_AfterComposite(uv_work_t* req, int)
         async_resource.runInAsyncScope(Nan::GetCurrentContext()->Global(), Nan::New(closure->cb), 2, argv);
     }
 
-    closure->im1->Unref();
-    closure->im2->Unref();
+    closure->im1->_unref();
+    closure->im2->_unref();
     closure->cb.Reset();
     delete closure;
 }

--- a/src/mapnik_image.cpp
+++ b/src/mapnik_image.cpp
@@ -1630,9 +1630,17 @@ void Image::EIO_AfterCopy(uv_work_t* req, int)
         Image* im = new Image(closure->im2);
         v8::Local<v8::Value> ext = Nan::New<v8::External>(im);
         Nan::MaybeLocal<v8::Object> maybe_local = Nan::NewInstance(Nan::GetFunction(Nan::New(constructor)).ToLocalChecked(), 1, &ext);
-        if (maybe_local.IsEmpty()) Nan::ThrowError("Could not create new Image instance");
-        v8::Local<v8::Value> argv[2] = { Nan::Null(), maybe_local.ToLocalChecked() };
-        async_resource.runInAsyncScope(Nan::GetCurrentContext()->Global(), Nan::New(closure->cb), 2, argv);
+
+		if (maybe_local.IsEmpty())
+		{
+			v8::Local<v8::Value> argv[1] = { Nan::Error("Could not create new Image instance") };
+			async_resource.runInAsyncScope(Nan::GetCurrentContext()->Global(), Nan::New(closure->cb), 1, argv);
+		}
+		else
+		{
+			v8::Local<v8::Value> argv[2] = { Nan::Null(), maybe_local.ToLocalChecked() };
+			async_resource.runInAsyncScope(Nan::GetCurrentContext()->Global(), Nan::New(closure->cb), 2, argv);
+		}
     }
     closure->im1->_unref();
     closure->cb.Reset();
@@ -2096,9 +2104,17 @@ void Image::EIO_AfterResize(uv_work_t* req, int)
         Image* im = new Image(closure->im2);
         v8::Local<v8::Value> ext = Nan::New<v8::External>(im);
         Nan::MaybeLocal<v8::Object> maybe_local = Nan::NewInstance(Nan::GetFunction(Nan::New(constructor)).ToLocalChecked(), 1, &ext);
-        if (maybe_local.IsEmpty()) Nan::ThrowError("Could not create new Image instance");
-        v8::Local<v8::Value> argv[2] = { Nan::Null(), maybe_local.ToLocalChecked() };
-        async_resource.runInAsyncScope(Nan::GetCurrentContext()->Global(), Nan::New(closure->cb), 2, argv);
+
+		if (maybe_local.IsEmpty())
+		{
+			v8::Local<v8::Value> argv[1] = { Nan::Error("Could not create new Image instance") };
+			async_resource.runInAsyncScope(Nan::GetCurrentContext()->Global(), Nan::New(closure->cb), 1, argv);
+		}
+		else
+		{
+			v8::Local<v8::Value> argv[2] = { Nan::Null(), maybe_local.ToLocalChecked() };
+			async_resource.runInAsyncScope(Nan::GetCurrentContext()->Global(), Nan::New(closure->cb), 2, argv);
+		}
     }
     closure->im1->_unref();
     closure->cb.Reset();
@@ -2533,9 +2549,16 @@ void Image::EIO_AfterOpen(uv_work_t* req, int)
         Image* im = new Image(closure->im);
         v8::Local<v8::Value> ext = Nan::New<v8::External>(im);
         Nan::MaybeLocal<v8::Object> maybe_local = Nan::NewInstance(Nan::GetFunction(Nan::New(constructor)).ToLocalChecked(), 1, &ext);
-        if (maybe_local.IsEmpty()) Nan::ThrowError("Could not create new Image instance");
-        v8::Local<v8::Value> argv[2] = { Nan::Null(), maybe_local.ToLocalChecked() };
-        async_resource.runInAsyncScope(Nan::GetCurrentContext()->Global(), Nan::New(closure->cb), 2, argv);
+		if (maybe_local.IsEmpty())
+		{
+			v8::Local<v8::Value> argv[1] = { Nan::Error("Could not create new Image instance") };
+			async_resource.runInAsyncScope(Nan::GetCurrentContext()->Global(), Nan::New(closure->cb), 1, argv);
+		}
+		else
+		{
+			v8::Local<v8::Value> argv[2] = { Nan::Null(), maybe_local.ToLocalChecked() };
+			async_resource.runInAsyncScope(Nan::GetCurrentContext()->Global(), Nan::New(closure->cb), 2, argv);
+		}
     }
     closure->cb.Reset();
     delete closure;
@@ -3034,9 +3057,16 @@ void Image::EIO_AfterFromSVG(uv_work_t* req, int)
         Image* im = new Image(closure->im);
         v8::Local<v8::Value> ext = Nan::New<v8::External>(im);
         Nan::MaybeLocal<v8::Object> maybe_local = Nan::NewInstance(Nan::GetFunction(Nan::New(constructor)).ToLocalChecked(), 1, &ext);
-        if (maybe_local.IsEmpty()) Nan::ThrowError("Could not create new Image instance");
-        v8::Local<v8::Value> argv[2] = { Nan::Null(), maybe_local.ToLocalChecked() };
-        async_resource.runInAsyncScope(Nan::GetCurrentContext()->Global(), Nan::New(closure->cb), 2, argv);
+		if (maybe_local.IsEmpty())
+		{
+			v8::Local<v8::Value> argv[1] = { Nan::Error("Could not create new Image instance") };
+			async_resource.runInAsyncScope(Nan::GetCurrentContext()->Global(), Nan::New(closure->cb), 1, argv);
+		}
+		else
+		{
+			v8::Local<v8::Value> argv[2] = { Nan::Null(), maybe_local.ToLocalChecked() };
+			async_resource.runInAsyncScope(Nan::GetCurrentContext()->Global(), Nan::New(closure->cb), 2, argv);
+		}
     }
     closure->cb.Reset();
     delete closure;
@@ -3276,10 +3306,17 @@ void Image::EIO_AfterFromSVGBytes(uv_work_t* req, int)
         Image* im = new Image(closure->im);
         v8::Local<v8::Value> ext = Nan::New<v8::External>(im);
         Nan::MaybeLocal<v8::Object> maybe_local = Nan::NewInstance(Nan::GetFunction(Nan::New(constructor)).ToLocalChecked(), 1, &ext);
-        if (maybe_local.IsEmpty()) Nan::ThrowError("Could not create new Image instance");
-        v8::Local<v8::Object> image_obj = maybe_local.ToLocalChecked()->ToObject(Nan::GetCurrentContext()).ToLocalChecked();
-        v8::Local<v8::Value> argv[2] = { Nan::Null(), image_obj };
-        async_resource.runInAsyncScope(Nan::GetCurrentContext()->Global(), Nan::New(closure->cb), 2, argv);
+		if (maybe_local.IsEmpty())
+		{
+			v8::Local<v8::Value> argv[1] = { Nan::Error("Could not create new Image instance") };
+			async_resource.runInAsyncScope(Nan::GetCurrentContext()->Global(), Nan::New(closure->cb), 1, argv);
+		}
+		else
+		{
+			v8::Local<v8::Object> image_obj = maybe_local.ToLocalChecked()->ToObject(Nan::GetCurrentContext()).ToLocalChecked();
+			v8::Local<v8::Value> argv[2] = { Nan::Null(), image_obj };
+			async_resource.runInAsyncScope(Nan::GetCurrentContext()->Global(), Nan::New(closure->cb), 2, argv);
+		}
     }
     closure->cb.Reset();
     closure->buffer.Reset();
@@ -3624,9 +3661,16 @@ void Image::EIO_AfterFromBytes(uv_work_t* req, int)
         Image* im = new Image(closure->im);
         v8::Local<v8::Value> ext = Nan::New<v8::External>(im);
         Nan::MaybeLocal<v8::Object> maybe_local = Nan::NewInstance(Nan::GetFunction(Nan::New(constructor)).ToLocalChecked(), 1, &ext);
-        if (maybe_local.IsEmpty()) Nan::ThrowError("Could not create new Image instance");
-        v8::Local<v8::Value> argv[2] = { Nan::Null(), maybe_local.ToLocalChecked() };
-        async_resource.runInAsyncScope(Nan::GetCurrentContext()->Global(), Nan::New(closure->cb), 2, argv);
+		if (maybe_local.IsEmpty())
+		{
+			v8::Local<v8::Value> argv[1] = { Nan::Error("Could not create new Image instance") };
+			async_resource.runInAsyncScope(Nan::GetCurrentContext()->Global(), Nan::New(closure->cb), 1, argv);
+		}
+		else
+		{
+			v8::Local<v8::Value> argv[2] = { Nan::Null(), maybe_local.ToLocalChecked() };
+			async_resource.runInAsyncScope(Nan::GetCurrentContext()->Global(), Nan::New(closure->cb), 2, argv);
+		}
     }
     closure->cb.Reset();
     closure->buffer.Reset();

--- a/src/mapnik_image.cpp
+++ b/src/mapnik_image.cpp
@@ -769,7 +769,7 @@ void Image::EIO_Filter(uv_work_t* req)
     }
 }
 
-void Image::EIO_AfterFilter(uv_work_t* req)
+void Image::EIO_AfterFilter(uv_work_t* req, int)
 {
     Nan::HandleScope scope;
 	Nan::AsyncResource async_resource(__func__);
@@ -994,7 +994,7 @@ void Image::EIO_Fill(uv_work_t* req)
     }
 }
 
-void Image::EIO_AfterFill(uv_work_t* req)
+void Image::EIO_AfterFill(uv_work_t* req, int)
 {
     Nan::HandleScope scope;
 	Nan::AsyncResource async_resource(__func__);
@@ -1108,7 +1108,7 @@ void Image::EIO_Clear(uv_work_t* req)
     }
 }
 
-void Image::EIO_AfterClear(uv_work_t* req)
+void Image::EIO_AfterClear(uv_work_t* req, int)
 {
     Nan::HandleScope scope;
 	Nan::AsyncResource async_resource(__func__);
@@ -1264,7 +1264,7 @@ void Image::EIO_Premultiply(uv_work_t* req)
     mapnik::premultiply_alpha(*closure->im->this_);
 }
 
-void Image::EIO_AfterMultiply(uv_work_t* req)
+void Image::EIO_AfterMultiply(uv_work_t* req, int)
 {
     Nan::HandleScope scope;
 	Nan::AsyncResource async_resource(__func__);
@@ -1399,7 +1399,7 @@ void Image::EIO_IsSolid(uv_work_t* req)
     }
 }
 
-void Image::EIO_AfterIsSolid(uv_work_t* req)
+void Image::EIO_AfterIsSolid(uv_work_t* req, int)
 {
     Nan::HandleScope scope;
 	Nan::AsyncResource async_resource(__func__);
@@ -1606,7 +1606,7 @@ void Image::EIO_Copy(uv_work_t* req)
     }
 }
 
-void Image::EIO_AfterCopy(uv_work_t* req)
+void Image::EIO_AfterCopy(uv_work_t* req, int)
 {
     Nan::HandleScope scope;
 	Nan::AsyncResource async_resource(__func__);
@@ -2081,7 +2081,7 @@ void Image::EIO_Resize(uv_work_t* req)
     }
 }
 
-void Image::EIO_AfterResize(uv_work_t* req)
+void Image::EIO_AfterResize(uv_work_t* req, int)
 {
     Nan::HandleScope scope;
 	Nan::AsyncResource async_resource(__func__);
@@ -2518,7 +2518,7 @@ void Image::EIO_Open(uv_work_t* req)
     }
 }
 
-void Image::EIO_AfterOpen(uv_work_t* req)
+void Image::EIO_AfterOpen(uv_work_t* req, int)
 {
     Nan::HandleScope scope;
 	Nan::AsyncResource async_resource(__func__);
@@ -3019,7 +3019,7 @@ void Image::EIO_FromSVG(uv_work_t* req)
     }
 }
 
-void Image::EIO_AfterFromSVG(uv_work_t* req)
+void Image::EIO_AfterFromSVG(uv_work_t* req, int)
 {
     Nan::HandleScope scope;
 	Nan::AsyncResource async_resource(__func__);
@@ -3261,7 +3261,7 @@ void Image::EIO_FromSVGBytes(uv_work_t* req)
     }
 }
 
-void Image::EIO_AfterFromSVGBytes(uv_work_t* req)
+void Image::EIO_AfterFromSVGBytes(uv_work_t* req, int)
 {
     Nan::HandleScope scope;
 	Nan::AsyncResource async_resource(__func__);
@@ -3600,7 +3600,7 @@ void Image::EIO_FromBytes(uv_work_t* req)
     }
 }
 
-void Image::EIO_AfterFromBytes(uv_work_t* req)
+void Image::EIO_AfterFromBytes(uv_work_t* req, int)
 {
     Nan::HandleScope scope;
 	Nan::AsyncResource async_resource(__func__);
@@ -3831,7 +3831,7 @@ void Image::EIO_Encode(uv_work_t* req)
     }
 }
 
-void Image::EIO_AfterEncode(uv_work_t* req)
+void Image::EIO_AfterEncode(uv_work_t* req, int)
 {
     Nan::HandleScope scope;
 	Nan::AsyncResource async_resource(__func__);
@@ -4035,7 +4035,7 @@ void Image::EIO_Save(uv_work_t* req)
     }
 }
 
-void Image::EIO_AfterSave(uv_work_t* req)
+void Image::EIO_AfterSave(uv_work_t* req, int)
 {
     Nan::HandleScope scope;
 	Nan::AsyncResource async_resource(__func__);
@@ -4265,7 +4265,7 @@ void Image::EIO_Composite(uv_work_t* req)
     }
 }
 
-void Image::EIO_AfterComposite(uv_work_t* req)
+void Image::EIO_AfterComposite(uv_work_t* req, int)
 {
     Nan::HandleScope scope;
 	Nan::AsyncResource async_resource(__func__);

--- a/src/mapnik_image.hpp
+++ b/src/mapnik_image.hpp
@@ -4,6 +4,7 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wshadow"
+#pragma GCC diagnostic ignored "-Wcast-function-type"
 #include <nan.h>
 #pragma GCC diagnostic pop
 
@@ -30,7 +31,7 @@ public:
     static NAN_METHOD(encodeSync);
     static NAN_METHOD(encode);
     static void EIO_Encode(uv_work_t* req);
-    static void EIO_AfterEncode(uv_work_t* req);
+    static void EIO_AfterEncode(uv_work_t* req, int);
 
     static NAN_METHOD(setGrayScaleToAlpha);
     static NAN_METHOD(width);
@@ -40,40 +41,40 @@ public:
     static NAN_METHOD(openSync);
     static NAN_METHOD(open);
     static void EIO_Open(uv_work_t* req);
-    static void EIO_AfterOpen(uv_work_t* req);
+    static void EIO_AfterOpen(uv_work_t* req, int);
     static v8::Local<v8::Value> _fromBytesSync(Nan::NAN_METHOD_ARGS_TYPE info);
     static v8::Local<v8::Value> _fromBufferSync(Nan::NAN_METHOD_ARGS_TYPE info);
     static NAN_METHOD(fromBytesSync);
     static NAN_METHOD(fromBufferSync);
     static NAN_METHOD(fromBytes);
     static void EIO_FromBytes(uv_work_t* req);
-    static void EIO_AfterFromBytes(uv_work_t* req);
+    static void EIO_AfterFromBytes(uv_work_t* req, int);
     static v8::Local<v8::Value> _fromSVGSync(bool fromFile, Nan::NAN_METHOD_ARGS_TYPE info);
     static NAN_METHOD(fromSVGSync);
     static NAN_METHOD(fromSVG);
     static NAN_METHOD(fromSVGBytesSync);
     static NAN_METHOD(fromSVGBytes);
     static void EIO_FromSVG(uv_work_t* req);
-    static void EIO_AfterFromSVG(uv_work_t* req);
+    static void EIO_AfterFromSVG(uv_work_t* req, int);
     static void EIO_FromSVGBytes(uv_work_t* req);
-    static void EIO_AfterFromSVGBytes(uv_work_t* req);
+    static void EIO_AfterFromSVGBytes(uv_work_t* req, int);
     static v8::Local<v8::Value> _saveSync(Nan::NAN_METHOD_ARGS_TYPE info);
     static NAN_METHOD(saveSync);
     static NAN_METHOD(save);
     static void EIO_Save(uv_work_t* req);
-    static void EIO_AfterSave(uv_work_t* req);
+    static void EIO_AfterSave(uv_work_t* req, int);
     static NAN_METHOD(painted);
     static NAN_METHOD(composite);
     static v8::Local<v8::Value> _filterSync(Nan::NAN_METHOD_ARGS_TYPE info);
     static NAN_METHOD(filterSync);
     static NAN_METHOD(filter);
     static void EIO_Filter(uv_work_t* req);
-    static void EIO_AfterFilter(uv_work_t* req);
+    static void EIO_AfterFilter(uv_work_t* req, int);
     static v8::Local<v8::Value> _fillSync(Nan::NAN_METHOD_ARGS_TYPE info);
     static NAN_METHOD(fillSync);
     static NAN_METHOD(fill);
     static void EIO_Fill(uv_work_t* req);
-    static void EIO_AfterFill(uv_work_t* req);
+    static void EIO_AfterFill(uv_work_t* req, int);
     static v8::Local<v8::Value> _premultiplySync(Nan::NAN_METHOD_ARGS_TYPE info);
     static NAN_METHOD(premultiplySync);
     static NAN_METHOD(premultiply);
@@ -83,28 +84,28 @@ public:
     static NAN_METHOD(demultiplySync);
     static NAN_METHOD(demultiply);
     static void EIO_Demultiply(uv_work_t* req);
-    static void EIO_AfterMultiply(uv_work_t* req);
+    static void EIO_AfterMultiply(uv_work_t* req, int);
     static v8::Local<v8::Value> _clearSync(Nan::NAN_METHOD_ARGS_TYPE info);
     static NAN_METHOD(clearSync);
     static NAN_METHOD(clear);
     static void EIO_Clear(uv_work_t* req);
-    static void EIO_AfterClear(uv_work_t* req);
+    static void EIO_AfterClear(uv_work_t* req, int);
     static void EIO_Composite(uv_work_t* req);
-    static void EIO_AfterComposite(uv_work_t* req);
+    static void EIO_AfterComposite(uv_work_t* req, int);
     static NAN_METHOD(compare);
     static NAN_METHOD(isSolid);
     static void EIO_IsSolid(uv_work_t* req);
-    static void EIO_AfterIsSolid(uv_work_t* req);
+    static void EIO_AfterIsSolid(uv_work_t* req, int);
     static v8::Local<v8::Value> _isSolidSync(Nan::NAN_METHOD_ARGS_TYPE info);
     static NAN_METHOD(isSolidSync);
     static NAN_METHOD(copy);
     static void EIO_Copy(uv_work_t* req);
-    static void EIO_AfterCopy(uv_work_t* req);
+    static void EIO_AfterCopy(uv_work_t* req, int);
     static v8::Local<v8::Value> _copySync(Nan::NAN_METHOD_ARGS_TYPE info);
     static NAN_METHOD(copySync);
     static NAN_METHOD(resize);
     static void EIO_Resize(uv_work_t* req);
-    static void EIO_AfterResize(uv_work_t* req);
+    static void EIO_AfterResize(uv_work_t* req, int);
     static v8::Local<v8::Value> _resizeSync(Nan::NAN_METHOD_ARGS_TYPE info);
     static NAN_METHOD(resizeSync);
     static NAN_METHOD(data);

--- a/src/mapnik_image_view.cpp
+++ b/src/mapnik_image_view.cpp
@@ -134,7 +134,7 @@ NAN_METHOD(ImageView::isSolid)
     closure->error = false;
     closure->cb.Reset(callback.As<v8::Function>());
     uv_queue_work(uv_default_loop(), &closure->request, EIO_IsSolid, (uv_after_work_cb)EIO_AfterIsSolid);
-    im->Ref();
+    im->_ref();
     return;
 }
 
@@ -275,7 +275,7 @@ void ImageView::EIO_AfterIsSolid(uv_work_t* req, int)
             async_resource.runInAsyncScope(Nan::GetCurrentContext()->Global(), Nan::New(closure->cb), 2, argv);
         }
     }
-    closure->im->Unref();
+    closure->im->_unref();
     closure->cb.Reset();
     delete closure;
 }
@@ -505,7 +505,7 @@ NAN_METHOD(ImageView::encode)
     baton->palette = palette;
     baton->cb.Reset(callback.As<v8::Function>());
     uv_queue_work(uv_default_loop(), &baton->request, AsyncEncode, (uv_after_work_cb)EIO_AfterEncode);
-    im->Ref();
+    im->_ref();
     return;
 }
 
@@ -546,7 +546,7 @@ void ImageView::EIO_AfterEncode(uv_work_t* req, int)
         async_resource.runInAsyncScope(Nan::GetCurrentContext()->Global(), Nan::New(baton->cb), 2, argv);
     }
 
-    baton->im->Unref();
+    baton->im->_unref();
     baton->cb.Reset();
     delete baton;
 }

--- a/src/mapnik_image_view.cpp
+++ b/src/mapnik_image_view.cpp
@@ -250,7 +250,7 @@ struct visitor_get_pixel_view
 
 };
 
-void ImageView::EIO_AfterIsSolid(uv_work_t* req)
+void ImageView::EIO_AfterIsSolid(uv_work_t* req, int)
 {
     Nan::HandleScope scope;
 	Nan::AsyncResource async_resource(__func__);
@@ -504,7 +504,7 @@ NAN_METHOD(ImageView::encode)
     baton->format = format;
     baton->palette = palette;
     baton->cb.Reset(callback.As<v8::Function>());
-    uv_queue_work(uv_default_loop(), &baton->request, AsyncEncode, (uv_after_work_cb)AfterEncode);
+    uv_queue_work(uv_default_loop(), &baton->request, AsyncEncode, (uv_after_work_cb)EIO_AfterEncode);
     im->Ref();
     return;
 }
@@ -529,7 +529,7 @@ void ImageView::AsyncEncode(uv_work_t* req)
     }
 }
 
-void ImageView::AfterEncode(uv_work_t* req)
+void ImageView::EIO_AfterEncode(uv_work_t* req, int)
 {
     Nan::HandleScope scope;
 	Nan::AsyncResource async_resource(__func__);

--- a/src/mapnik_image_view.hpp
+++ b/src/mapnik_image_view.hpp
@@ -4,6 +4,7 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wshadow"
+#pragma GCC diagnostic ignored "-Wcast-function-type"
 #include <nan.h>
 #pragma GCC diagnostic pop
 
@@ -29,7 +30,7 @@ public:
     static NAN_METHOD(encodeSync);
     static NAN_METHOD(encode);
     static void AsyncEncode(uv_work_t* req);
-    static void AfterEncode(uv_work_t* req);
+    static void EIO_AfterEncode(uv_work_t* req, int);
 
     //static NAN_METHOD(view);
     static NAN_METHOD(width);
@@ -38,7 +39,7 @@ public:
     static NAN_METHOD(save);
     static NAN_METHOD(isSolid);
     static void EIO_IsSolid(uv_work_t* req);
-    static void EIO_AfterIsSolid(uv_work_t* req);
+    static void EIO_AfterIsSolid(uv_work_t* req, int);
     static v8::Local<v8::Value> _isSolidSync(Nan::NAN_METHOD_ARGS_TYPE info);
     static NAN_METHOD(isSolidSync);
     static NAN_METHOD(getPixel);

--- a/src/mapnik_image_view.hpp
+++ b/src/mapnik_image_view.hpp
@@ -46,6 +46,9 @@ public:
 
     ImageView(Image * JSImage);
 
+    void _ref() { Ref(); }
+    void _unref() { Unref(); }
+
 private:
     ~ImageView();
     image_view_ptr this_;

--- a/src/mapnik_layer.hpp
+++ b/src/mapnik_layer.hpp
@@ -4,6 +4,7 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wshadow"
+#pragma GCC diagnostic ignored "-Wcast-function-type"
 #include <nan.h>
 #pragma GCC diagnostic pop
 

--- a/src/mapnik_logger.hpp
+++ b/src/mapnik_logger.hpp
@@ -1,7 +1,12 @@
 #ifndef __NODE_MAPNIK_LOGGER_H__
 #define __NODE_MAPNIK_LOGGER_H__
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+#pragma GCC diagnostic ignored "-Wshadow"
+#pragma GCC diagnostic ignored "-Wcast-function-type"
 #include <nan.h>
+#pragma GCC diagnostic pop
 
 //Forward declaration of mapnik logger
 namespace mapnik { class logger; }

--- a/src/mapnik_map.cpp
+++ b/src/mapnik_map.cpp
@@ -851,7 +851,7 @@ void Map::EIO_QueryMap(uv_work_t* req)
     }
 }
 
-void Map::EIO_AfterQueryMap(uv_work_t* req)
+void Map::EIO_AfterQueryMap(uv_work_t* req, int)
 {
     Nan::HandleScope scope;
 	Nan::AsyncResource async_resource(__func__);
@@ -1147,7 +1147,7 @@ void Map::EIO_Load(uv_work_t* req)
     }
 }
 
-void Map::EIO_AfterLoad(uv_work_t* req)
+void Map::EIO_AfterLoad(uv_work_t* req, int)
 {
     Nan::HandleScope scope;
 	Nan::AsyncResource async_resource(__func__);
@@ -1426,7 +1426,7 @@ void Map::EIO_FromString(uv_work_t* req)
     }
 }
 
-void Map::EIO_AfterFromString(uv_work_t* req)
+void Map::EIO_AfterFromString(uv_work_t* req, int)
 {
     Nan::HandleScope scope;
 	Nan::AsyncResource async_resource(__func__);
@@ -2198,7 +2198,7 @@ void Map::EIO_RenderVectorTile(uv_work_t* req)
     }
 }
 
-void Map::EIO_AfterRenderVectorTile(uv_work_t* req)
+void Map::EIO_AfterRenderVectorTile(uv_work_t* req, int)
 {
     Nan::HandleScope scope;
 	Nan::AsyncResource async_resource(__func__);
@@ -2269,7 +2269,7 @@ void Map::EIO_RenderGrid(uv_work_t* req)
     }
 }
 
-void Map::EIO_AfterRenderGrid(uv_work_t* req)
+void Map::EIO_AfterRenderGrid(uv_work_t* req, int)
 {
     Nan::HandleScope scope;
 	Nan::AsyncResource async_resource(__func__);
@@ -2321,7 +2321,7 @@ void Map::EIO_RenderImage(uv_work_t* req)
     }
 }
 
-void Map::EIO_AfterRenderImage(uv_work_t* req)
+void Map::EIO_AfterRenderImage(uv_work_t* req, int)
 {
     Nan::HandleScope scope;
 	Nan::AsyncResource async_resource(__func__);
@@ -2554,7 +2554,7 @@ void Map::EIO_RenderFile(uv_work_t* req)
     }
 }
 
-void Map::EIO_AfterRenderFile(uv_work_t* req)
+void Map::EIO_AfterRenderFile(uv_work_t* req, int)
 {
     Nan::HandleScope scope;
 	Nan::AsyncResource async_resource(__func__);

--- a/src/mapnik_map.cpp
+++ b/src/mapnik_map.cpp
@@ -791,7 +791,7 @@ v8::Local<v8::Value> Map::abstractQueryPoint(Nan::NAN_METHOD_ARGS_TYPE info, boo
     closure->error = false;
     closure->cb.Reset(callback.As<v8::Function>());
     uv_queue_work(uv_default_loop(), &closure->request, EIO_QueryMap, (uv_after_work_cb)EIO_AfterQueryMap);
-    m->Ref();
+    m->_ref();
     return Nan::Undefined();
 }
 
@@ -854,7 +854,7 @@ void Map::EIO_QueryMap(uv_work_t* req)
 void Map::EIO_AfterQueryMap(uv_work_t* req, int)
 {
     Nan::HandleScope scope;
-	Nan::AsyncResource async_resource(__func__);
+    Nan::AsyncResource async_resource(__func__);
     query_map_baton_t *closure = static_cast<query_map_baton_t *>(req->data);
     if (closure->error) {
         v8::Local<v8::Value> argv[1] = { Nan::Error(closure->error_name.c_str()) };
@@ -887,7 +887,7 @@ void Map::EIO_AfterQueryMap(uv_work_t* req, int)
         }
     }
 
-    closure->m->Unref();
+    closure->m->_unref();
     closure->cb.Reset();
     delete closure;
 }
@@ -1128,7 +1128,7 @@ NAN_METHOD(Map::load)
     closure->error = false;
     closure->cb.Reset(callback.As<v8::Function>());
     uv_queue_work(uv_default_loop(), &closure->request, EIO_Load, (uv_after_work_cb)EIO_AfterLoad);
-    m->Ref();
+    m->_ref();
     return;
 }
 
@@ -1160,7 +1160,7 @@ void Map::EIO_AfterLoad(uv_work_t* req, int)
         async_resource.runInAsyncScope(Nan::GetCurrentContext()->Global(), Nan::New(closure->cb), 2, argv);
     }
 
-    closure->m->Unref();
+    closure->m->_unref();
     closure->cb.Reset();
     delete closure;
 }
@@ -1407,7 +1407,7 @@ NAN_METHOD(Map::fromString)
     closure->error = false;
     closure->cb.Reset(callback.As<v8::Function>());
     uv_queue_work(uv_default_loop(), &closure->request, EIO_FromString, (uv_after_work_cb)EIO_AfterFromString);
-    m->Ref();
+    m->_ref();
     return;
 }
 
@@ -1439,7 +1439,7 @@ void Map::EIO_AfterFromString(uv_work_t* req, int)
         async_resource.runInAsyncScope(Nan::GetCurrentContext()->Global(), Nan::New(closure->cb), 2, argv);
     }
 
-    closure->m->Unref();
+    closure->m->_unref();
     closure->cb.Reset();
     delete closure;
 }
@@ -1825,7 +1825,6 @@ NAN_METHOD(Map::render)
             closure->request.data = closure;
             closure->m = m;
             closure->im = Nan::ObjectWrap::Unwrap<Image>(obj);
-            closure->im->_ref();
             closure->buffer_size = buffer_size;
             closure->scale_factor = scale_factor;
             closure->scale_denominator = scale_denominator;
@@ -1852,7 +1851,7 @@ NAN_METHOD(Map::render)
             }
             closure->cb.Reset(info[info.Length() - 1].As<v8::Function>());
             uv_queue_work(uv_default_loop(), &closure->request, EIO_RenderImage, (uv_after_work_cb)EIO_AfterRenderImage);
-
+            closure->im->_ref();
         }
 #if defined(GRID_RENDERER)
         else if (Nan::New(Grid::constructor)->HasInstance(obj)) {
@@ -1953,7 +1952,6 @@ NAN_METHOD(Map::render)
             closure->request.data = closure;
             closure->m = m;
             closure->g = g;
-            closure->g->_ref();
             closure->layer_idx = layer_idx;
             closure->buffer_size = buffer_size;
             closure->scale_factor = scale_factor;
@@ -1969,6 +1967,7 @@ NAN_METHOD(Map::render)
             }
             closure->cb.Reset(info[info.Length() - 1].As<v8::Function>());
             uv_queue_work(uv_default_loop(), &closure->request, EIO_RenderGrid, (uv_after_work_cb)EIO_AfterRenderGrid);
+            closure->g->_ref();
         }
 #endif
         else if (Nan::New(VectorTile::constructor)->HasInstance(obj))
@@ -2133,7 +2132,6 @@ NAN_METHOD(Map::render)
             closure->request.data = closure;
             closure->m = m;
             closure->d = Nan::ObjectWrap::Unwrap<VectorTile>(obj);
-            closure->d->_ref();
             closure->scale_factor = scale_factor;
             closure->scale_denominator = scale_denominator;
             closure->offset_x = offset_x;
@@ -2147,6 +2145,7 @@ NAN_METHOD(Map::render)
             }
             closure->cb.Reset(info[info.Length() - 1].As<v8::Function>());
             uv_queue_work(uv_default_loop(), &closure->request, EIO_RenderVectorTile, (uv_after_work_cb)EIO_AfterRenderVectorTile);
+            closure->d->_ref();
         }
         else
         {
@@ -2154,7 +2153,7 @@ NAN_METHOD(Map::render)
             return;
         }
 
-        m->Ref();
+        m->_ref();
         return;
     }
     catch (std::exception const& ex)
@@ -2216,7 +2215,7 @@ void Map::EIO_AfterRenderVectorTile(uv_work_t* req, int)
         async_resource.runInAsyncScope(Nan::GetCurrentContext()->Global(), Nan::New(closure->cb), 2, argv);
     }
 
-    closure->m->Unref();
+    closure->m->_unref();
     closure->d->_unref();
     closure->cb.Reset();
     delete closure;
@@ -2286,7 +2285,7 @@ void Map::EIO_AfterRenderGrid(uv_work_t* req, int)
         async_resource.runInAsyncScope(Nan::GetCurrentContext()->Global(), Nan::New(closure->cb), 2, argv);
     }
 
-    closure->m->Unref();
+    closure->m->_unref();
     closure->g->_unref();
     closure->cb.Reset();
     delete closure;
@@ -2324,7 +2323,7 @@ void Map::EIO_RenderImage(uv_work_t* req)
 void Map::EIO_AfterRenderImage(uv_work_t* req, int)
 {
     Nan::HandleScope scope;
-	Nan::AsyncResource async_resource(__func__);
+    Nan::AsyncResource async_resource(__func__);
     image_baton_t *closure = static_cast<image_baton_t *>(req->data);
     closure->m->release();
 
@@ -2336,7 +2335,7 @@ void Map::EIO_AfterRenderImage(uv_work_t* req, int)
         async_resource.runInAsyncScope(Nan::GetCurrentContext()->Global(), Nan::New(closure->cb), 2, argv);
     }
 
-    closure->m->Unref();
+    closure->m->_unref();
     closure->im->_unref();
     closure->cb.Reset();
     delete closure;
@@ -2507,7 +2506,7 @@ NAN_METHOD(Map::renderFile)
     closure->output = output;
 
     uv_queue_work(uv_default_loop(), &closure->request, EIO_RenderFile, (uv_after_work_cb)EIO_AfterRenderFile);
-    m->Ref();
+    m->_ref();
 
     return;
 
@@ -2569,7 +2568,7 @@ void Map::EIO_AfterRenderFile(uv_work_t* req, int)
         async_resource.runInAsyncScope(Nan::GetCurrentContext()->Global(), Nan::New(closure->cb), 1, argv);
     }
 
-    closure->m->Unref();
+    closure->m->_unref();
     closure->cb.Reset();
     delete closure;
 

--- a/src/mapnik_map.hpp
+++ b/src/mapnik_map.hpp
@@ -4,6 +4,7 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wshadow"
+#pragma GCC diagnostic ignored "-Wcast-function-type"
 #include <nan.h>
 #pragma GCC diagnostic pop
 
@@ -33,28 +34,28 @@ public:
     static NAN_METHOD(loadSync);
     static NAN_METHOD(load);
     static void EIO_Load(uv_work_t* req);
-    static void EIO_AfterLoad(uv_work_t* req);
+    static void EIO_AfterLoad(uv_work_t* req, int);
 
     static NAN_METHOD(fromStringSync);
     static NAN_METHOD(fromString);
     static void EIO_FromString(uv_work_t* req);
-    static void EIO_AfterFromString(uv_work_t* req);
+    static void EIO_AfterFromString(uv_work_t* req, int);
     static NAN_METHOD(clone);
 
     // async rendering
     static NAN_METHOD(render);
     static void EIO_RenderImage(uv_work_t* req);
-    static void EIO_AfterRenderImage(uv_work_t* req);
+    static void EIO_AfterRenderImage(uv_work_t* req, int);
 #if defined(GRID_RENDERER)
     static void EIO_RenderGrid(uv_work_t* req);
-    static void EIO_AfterRenderGrid(uv_work_t* req);
+    static void EIO_AfterRenderGrid(uv_work_t* req, int);
 #endif
     static void EIO_RenderVectorTile(uv_work_t* req);
-    static void EIO_AfterRenderVectorTile(uv_work_t* req);
+    static void EIO_AfterRenderVectorTile(uv_work_t* req, int);
 
     static NAN_METHOD(renderFile);
     static void EIO_RenderFile(uv_work_t* req);
-    static void EIO_AfterRenderFile(uv_work_t* req);
+    static void EIO_AfterRenderFile(uv_work_t* req, int);
 
     // sync rendering
     static NAN_METHOD(renderSync);
@@ -74,7 +75,7 @@ public:
     static NAN_METHOD(queryMapPoint);
     static v8::Local<v8::Value> abstractQueryPoint(Nan::NAN_METHOD_ARGS_TYPE info, bool geo_coords);
     static void EIO_QueryMap(uv_work_t* req);
-    static void EIO_AfterQueryMap(uv_work_t* req);
+    static void EIO_AfterQueryMap(uv_work_t* req, int);
 
     static NAN_METHOD(add_layer);
     static NAN_METHOD(get_layer);

--- a/src/mapnik_memory_datasource.hpp
+++ b/src/mapnik_memory_datasource.hpp
@@ -4,6 +4,7 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wshadow"
+#pragma GCC diagnostic ignored "-Wcast-function-type"
 #include <nan.h>
 #pragma GCC diagnostic pop
 

--- a/src/mapnik_palette.hpp
+++ b/src/mapnik_palette.hpp
@@ -4,6 +4,7 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wshadow"
+#pragma GCC diagnostic ignored "-Wcast-function-type"
 #include <nan.h>
 #pragma GCC diagnostic pop
 

--- a/src/mapnik_projection.hpp
+++ b/src/mapnik_projection.hpp
@@ -4,6 +4,7 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wshadow"
+#pragma GCC diagnostic ignored "-Wcast-function-type"
 #include <nan.h>
 #pragma GCC diagnostic pop
 

--- a/src/mapnik_vector_tile.cpp
+++ b/src/mapnik_vector_tile.cpp
@@ -1200,10 +1200,10 @@ NAN_METHOD(VectorTile::composite)
             return;
         }
         VectorTile* vt = Nan::ObjectWrap::Unwrap<VectorTile>(tile_obj);
-        vt->Ref();
+        vt->_ref();
         closure->vtiles.push_back(vt);
     }
-    closure->d->Ref();
+    closure->d->_ref();
     closure->cb.Reset(callback.As<v8::Function>());
     uv_queue_work(uv_default_loop(), &closure->request, EIO_Composite, (uv_after_work_cb)EIO_AfterComposite);
     return;
@@ -1257,9 +1257,9 @@ void VectorTile::EIO_AfterComposite(uv_work_t* req, int)
     }
     for (VectorTile* vt : closure->vtiles)
     {
-        vt->Unref();
+        vt->_unref();
     }
-    closure->d->Unref();
+    closure->d->_unref();
     closure->cb.Reset();
     delete closure;
 }
@@ -1633,7 +1633,7 @@ NAN_METHOD(VectorTile::query)
         closure->error = false;
         closure->cb.Reset(callback.As<v8::Function>());
         uv_queue_work(uv_default_loop(), &closure->request, EIO_Query, (uv_after_work_cb)EIO_AfterQuery);
-        d->Ref();
+        d->_ref();
         return;
     }
 }
@@ -1670,7 +1670,7 @@ void VectorTile::EIO_AfterQuery(uv_work_t* req, int)
         async_resource.runInAsyncScope(Nan::GetCurrentContext()->Global(), Nan::New(closure->cb), 2, argv);
     }
 
-    closure->d->Unref();
+    closure->d->_unref();
     closure->cb.Reset();
     delete closure;
 }
@@ -1978,7 +1978,7 @@ NAN_METHOD(VectorTile::queryMany)
         closure->request.data = closure;
         closure->cb.Reset(callback.As<v8::Function>());
         uv_queue_work(uv_default_loop(), &closure->request, EIO_QueryMany, (uv_after_work_cb)EIO_AfterQueryMany);
-        d->Ref();
+        d->_ref();
         return;
     }
 }
@@ -2179,7 +2179,7 @@ void VectorTile::EIO_AfterQueryMany(uv_work_t* req, int)
         async_resource.runInAsyncScope(Nan::GetCurrentContext()->Global(), Nan::New(closure->cb), 2, argv);
     }
 
-    closure->d->Unref();
+    closure->d->_unref();
     closure->cb.Reset();
     delete closure;
 }
@@ -3091,7 +3091,7 @@ NAN_METHOD(VectorTile::toGeoJSON)
     v8::Local<v8::Value> callback = info[info.Length()-1];
     closure->cb.Reset(callback.As<v8::Function>());
     uv_queue_work(uv_default_loop(), &closure->request, to_geojson, (uv_after_work_cb)after_to_geojson);
-    closure->v->Ref();
+    closure->v->_ref();
     return;
 }
 
@@ -3147,7 +3147,7 @@ void VectorTile::after_to_geojson(uv_work_t* req)
         v8::Local<v8::Value> argv[2] = { Nan::Null(), Nan::New<v8::String>(closure->result).ToLocalChecked() };
         async_resource.runInAsyncScope(Nan::GetCurrentContext()->Global(), Nan::New(closure->cb), 2, argv);
     }
-    closure->v->Unref();
+    closure->v->_unref();
     closure->cb.Reset();
     delete closure;
 }
@@ -3584,7 +3584,7 @@ NAN_METHOD(VectorTile::addImage)
     closure->error = false;
     closure->cb.Reset(callback.As<v8::Function>());
     uv_queue_work(uv_default_loop(), &closure->request, EIO_AddImage, (uv_after_work_cb)EIO_AfterAddImage);
-    d->Ref();
+    d->_ref();
     im->_ref();
     return;
 }
@@ -3638,7 +3638,7 @@ void VectorTile::EIO_AfterAddImage(uv_work_t* req, int)
         async_resource.runInAsyncScope(Nan::GetCurrentContext()->Global(), Nan::New(closure->cb), 1, argv);
     }
 
-    closure->d->Unref();
+    closure->d->_unref();
     closure->im->_unref();
     closure->cb.Reset();
     delete closure;
@@ -3786,7 +3786,7 @@ NAN_METHOD(VectorTile::addImageBuffer)
     closure->data = node::Buffer::Data(obj);
     closure->dataLength = node::Buffer::Length(obj);
     uv_queue_work(uv_default_loop(), &closure->request, EIO_AddImageBuffer, (uv_after_work_cb)EIO_AfterAddImageBuffer);
-    d->Ref();
+    d->_ref();
     return;
 }
 
@@ -3825,7 +3825,7 @@ void VectorTile::EIO_AfterAddImageBuffer(uv_work_t* req, int)
         async_resource.runInAsyncScope(Nan::GetCurrentContext()->Global(), Nan::New(closure->cb), 1, argv);
     }
 
-    closure->d->Unref();
+    closure->d->_unref();
     closure->cb.Reset();
     closure->buffer.Reset();
     delete closure;
@@ -4021,7 +4021,7 @@ NAN_METHOD(VectorTile::addData)
     closure->data = node::Buffer::Data(obj);
     closure->dataLength = node::Buffer::Length(obj);
     uv_queue_work(uv_default_loop(), &closure->request, EIO_AddData, (uv_after_work_cb)EIO_AfterAddData);
-    d->Ref();
+    d->_ref();
     return;
 }
 
@@ -4062,7 +4062,7 @@ void VectorTile::EIO_AfterAddData(uv_work_t* req, int)
         async_resource.runInAsyncScope(Nan::GetCurrentContext()->Global(), Nan::New(closure->cb), 1, argv);
     }
 
-    closure->d->Unref();
+    closure->d->_unref();
     closure->cb.Reset();
     closure->buffer.Reset();
     delete closure;
@@ -4258,7 +4258,7 @@ NAN_METHOD(VectorTile::setData)
     closure->data = node::Buffer::Data(obj);
     closure->dataLength = node::Buffer::Length(obj);
     uv_queue_work(uv_default_loop(), &closure->request, EIO_SetData, (uv_after_work_cb)EIO_AfterSetData);
-    d->Ref();
+    d->_ref();
     return;
 }
 
@@ -4301,7 +4301,7 @@ void VectorTile::EIO_AfterSetData(uv_work_t* req, int)
         async_resource.runInAsyncScope(Nan::GetCurrentContext()->Global(), Nan::New(closure->cb), 1, argv);
     }
 
-    closure->d->Unref();
+    closure->d->_unref();
     closure->cb.Reset();
     closure->buffer.Reset();
     delete closure;
@@ -4588,7 +4588,7 @@ NAN_METHOD(VectorTile::getData)
     closure->error = false;
     closure->cb.Reset(callback.As<v8::Function>());
     uv_queue_work(uv_default_loop(), &closure->request, get_data, (uv_after_work_cb)after_get_data);
-    d->Ref();
+    d->_ref();
     return;
 }
 
@@ -4662,7 +4662,7 @@ void VectorTile::after_get_data(uv_work_t* req)
         }
     }
 
-    closure->d->Unref();
+    closure->d->_unref();
     closure->cb.Reset();
     delete closure;
 }
@@ -4677,6 +4677,20 @@ using surface_type = mapnik::util::variant
      ,Grid *
 #endif
      >;
+
+struct ref_visitor
+{
+    void operator() (dummy_surface) {} // no-op
+    template <typename SurfaceType>
+    void operator() (SurfaceType * surface)
+    {
+        if (surface != nullptr)
+        {
+            surface->_ref();
+        }
+    }
+};
+
 
 struct deref_visitor
 {
@@ -4735,11 +4749,6 @@ struct vector_tile_render_baton_t
         zxy_override(false),
         error(false)
         {}
-
-    ~vector_tile_render_baton_t()
-    {
-        mapnik::util::apply_visitor(deref_visitor(),surface);
-    }
 };
 
 struct baton_guard
@@ -4958,7 +4967,6 @@ NAN_METHOD(VectorTile::render)
     if (Nan::New(Image::constructor)->HasInstance(im_obj))
     {
         Image *im = Nan::ObjectWrap::Unwrap<Image>(im_obj);
-        im->_ref();
         closure->width = im->get()->width();
         closure->height = im->get()->height();
         closure->surface = im;
@@ -4966,7 +4974,6 @@ NAN_METHOD(VectorTile::render)
     else if (Nan::New(CairoSurface::constructor)->HasInstance(im_obj))
     {
         CairoSurface *c = Nan::ObjectWrap::Unwrap<CairoSurface>(im_obj);
-        c->_ref();
         closure->width = c->width();
         closure->height = c->height();
         closure->surface = c;
@@ -4998,7 +5005,6 @@ NAN_METHOD(VectorTile::render)
     else if (Nan::New(Grid::constructor)->HasInstance(im_obj))
     {
         Grid *g = Nan::ObjectWrap::Unwrap<Grid>(im_obj);
-        g->_ref();
         closure->width = g->get()->width();
         closure->height = g->get()->height();
         closure->surface = g;
@@ -5099,8 +5105,9 @@ NAN_METHOD(VectorTile::render)
     closure->error = false;
     closure->cb.Reset(callback.As<v8::Function>());
     uv_queue_work(uv_default_loop(), &closure->request, EIO_RenderTile, (uv_after_work_cb)EIO_AfterRenderTile);
+    mapnik::util::apply_visitor(ref_visitor(), closure->surface);
     m->_ref();
-    d->Ref();
+    d->_ref();
     guard.release();
     return;
 }
@@ -5336,8 +5343,9 @@ void VectorTile::EIO_AfterRenderTile(uv_work_t* req, int)
         }
     }
 
+	mapnik::util::apply_visitor(deref_visitor(), closure->surface);
     closure->m->_unref();
-    closure->d->Unref();
+    closure->d->_unref();
     closure->cb.Reset();
     delete closure;
 }
@@ -5409,7 +5417,7 @@ NAN_METHOD(VectorTile::clear)
     closure->error = false;
     closure->cb.Reset(callback.As<v8::Function>());
     uv_queue_work(uv_default_loop(), &closure->request, EIO_Clear, (uv_after_work_cb)EIO_AfterClear);
-    d->Ref();
+    d->_ref();
     return;
 }
 
@@ -5448,7 +5456,7 @@ void VectorTile::EIO_AfterClear(uv_work_t* req, int)
         v8::Local<v8::Value> argv[1] = { Nan::Null() };
         async_resource.runInAsyncScope(Nan::GetCurrentContext()->Global(), Nan::New(closure->cb), 1, argv);
     }
-    closure->d->Unref();
+    closure->d->_unref();
     closure->cb.Reset();
     delete closure;
 }
@@ -6158,7 +6166,7 @@ NAN_METHOD(VectorTile::reportGeometrySimplicity)
     closure->error = false;
     closure->cb.Reset(callback.As<v8::Function>());
     uv_queue_work(uv_default_loop(), &closure->request, EIO_ReportGeometrySimplicity, (uv_after_work_cb)EIO_AfterReportGeometrySimplicity);
-    closure->v->Ref();
+    closure->v->_ref();
     return;
 }
 
@@ -6196,7 +6204,7 @@ void VectorTile::EIO_AfterReportGeometrySimplicity(uv_work_t* req, int)
         v8::Local<v8::Value> argv[2] = { Nan::Null(), array };
         async_resource.runInAsyncScope(Nan::GetCurrentContext()->Global(), Nan::New(closure->cb), 2, argv);
     }
-    closure->v->Unref();
+    closure->v->_unref();
     closure->cb.Reset();
     delete closure;
 }
@@ -6290,7 +6298,7 @@ NAN_METHOD(VectorTile::reportGeometryValidity)
     closure->web_merc = web_merc;
     closure->cb.Reset(callback.As<v8::Function>());
     uv_queue_work(uv_default_loop(), &closure->request, EIO_ReportGeometryValidity, (uv_after_work_cb)EIO_AfterReportGeometryValidity);
-    closure->v->Ref();
+    closure->v->_ref();
     return;
 }
 
@@ -6328,7 +6336,7 @@ void VectorTile::EIO_AfterReportGeometryValidity(uv_work_t* req, int)
         v8::Local<v8::Value> argv[2] = { Nan::Null(), array };
         async_resource.runInAsyncScope(Nan::GetCurrentContext()->Global(), Nan::New(closure->cb), 2, argv);
     }
-    closure->v->Unref();
+    closure->v->_unref();
     closure->cb.Reset();
     delete closure;
 }

--- a/src/mapnik_vector_tile.cpp
+++ b/src/mapnik_vector_tile.cpp
@@ -1239,7 +1239,7 @@ void VectorTile::EIO_Composite(uv_work_t* req)
     }
 }
 
-void VectorTile::EIO_AfterComposite(uv_work_t* req)
+void VectorTile::EIO_AfterComposite(uv_work_t* req, int)
 {
     Nan::HandleScope scope;
 	Nan::AsyncResource async_resource(__func__);
@@ -1652,7 +1652,7 @@ void VectorTile::EIO_Query(uv_work_t* req)
     }
 }
 
-void VectorTile::EIO_AfterQuery(uv_work_t* req)
+void VectorTile::EIO_AfterQuery(uv_work_t* req, int)
 {
     Nan::HandleScope scope;
 	Nan::AsyncResource async_resource(__func__);
@@ -2161,7 +2161,7 @@ void VectorTile::EIO_QueryMany(uv_work_t* req)
     }
 }
 
-void VectorTile::EIO_AfterQueryMany(uv_work_t* req)
+void VectorTile::EIO_AfterQueryMany(uv_work_t* req, int)
 {
     Nan::HandleScope scope;
 	Nan::AsyncResource async_resource(__func__);
@@ -3622,7 +3622,7 @@ void VectorTile::EIO_AddImage(uv_work_t* req)
     }
 }
 
-void VectorTile::EIO_AfterAddImage(uv_work_t* req)
+void VectorTile::EIO_AfterAddImage(uv_work_t* req, int)
 {
     Nan::HandleScope scope;
 	Nan::AsyncResource async_resource(__func__);
@@ -3807,7 +3807,7 @@ void VectorTile::EIO_AddImageBuffer(uv_work_t* req)
     }
 }
 
-void VectorTile::EIO_AfterAddImageBuffer(uv_work_t* req)
+void VectorTile::EIO_AfterAddImageBuffer(uv_work_t* req, int)
 {
     Nan::HandleScope scope;
 	Nan::AsyncResource async_resource(__func__);
@@ -4046,7 +4046,7 @@ void VectorTile::EIO_AddData(uv_work_t* req)
     }
 }
 
-void VectorTile::EIO_AfterAddData(uv_work_t* req)
+void VectorTile::EIO_AfterAddData(uv_work_t* req, int)
 {
     Nan::HandleScope scope;
 	Nan::AsyncResource async_resource(__func__);
@@ -4285,7 +4285,7 @@ void VectorTile::EIO_SetData(uv_work_t* req)
     }
 }
 
-void VectorTile::EIO_AfterSetData(uv_work_t* req)
+void VectorTile::EIO_AfterSetData(uv_work_t* req, int)
 {
     Nan::HandleScope scope;
 	Nan::AsyncResource async_resource(__func__);
@@ -5305,7 +5305,7 @@ void VectorTile::EIO_RenderTile(uv_work_t* req)
     }
 }
 
-void VectorTile::EIO_AfterRenderTile(uv_work_t* req)
+void VectorTile::EIO_AfterRenderTile(uv_work_t* req, int)
 {
     Nan::HandleScope scope;
 	Nan::AsyncResource async_resource(__func__);
@@ -5430,7 +5430,7 @@ void VectorTile::EIO_Clear(uv_work_t* req)
     }
 }
 
-void VectorTile::EIO_AfterClear(uv_work_t* req)
+void VectorTile::EIO_AfterClear(uv_work_t* req, int)
 {
     Nan::HandleScope scope;
 	Nan::AsyncResource async_resource(__func__);
@@ -6178,7 +6178,7 @@ void VectorTile::EIO_ReportGeometrySimplicity(uv_work_t* req)
     }
 }
 
-void VectorTile::EIO_AfterReportGeometrySimplicity(uv_work_t* req)
+void VectorTile::EIO_AfterReportGeometrySimplicity(uv_work_t* req, int)
 {
     Nan::HandleScope scope;
 	Nan::AsyncResource async_resource(__func__);
@@ -6310,7 +6310,7 @@ void VectorTile::EIO_ReportGeometryValidity(uv_work_t* req)
     }
 }
 
-void VectorTile::EIO_AfterReportGeometryValidity(uv_work_t* req)
+void VectorTile::EIO_AfterReportGeometryValidity(uv_work_t* req, int)
 {
     Nan::HandleScope scope;
 	Nan::AsyncResource async_resource(__func__);

--- a/src/mapnik_vector_tile.hpp
+++ b/src/mapnik_vector_tile.hpp
@@ -4,6 +4,7 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wshadow"
+#pragma GCC diagnostic ignored "-Wcast-function-type"
 #include <nan.h>
 #pragma GCC diagnostic pop
 
@@ -68,7 +69,7 @@ public:
     static NAN_METHOD(toJSON);
     static NAN_METHOD(query);
     static void EIO_Query(uv_work_t* req);
-    static void EIO_AfterQuery(uv_work_t* req);
+    static void EIO_AfterQuery(uv_work_t* req, int);
     static std::vector<query_result> _query(VectorTile* d, double lon, double lat, double tolerance, std::string const& layer_name);
     static bool _querySort(query_result const& a, query_result const& b);
     static v8::Local<v8::Array> _queryResultToV8(std::vector<query_result> const& result);
@@ -77,7 +78,7 @@ public:
     static bool _queryManySort(query_hit const& a, query_hit const& b);
     static v8::Local<v8::Object> _queryManyResultToV8(queryMany_result const& result);
     static void EIO_QueryMany(uv_work_t* req);
-    static void EIO_AfterQueryMany(uv_work_t* req);
+    static void EIO_AfterQueryMany(uv_work_t* req, int);
     static NAN_METHOD(extent);
     static NAN_METHOD(bufferedExtent);
     static NAN_METHOD(names);
@@ -92,48 +93,48 @@ public:
     static NAN_METHOD(addGeoJSON);
     static NAN_METHOD(addImage);
     static void EIO_AddImage(uv_work_t* req);
-    static void EIO_AfterAddImage(uv_work_t* req);
+    static void EIO_AfterAddImage(uv_work_t* req, int);
     static v8::Local<v8::Value> _addImageSync(Nan::NAN_METHOD_ARGS_TYPE info);
     static NAN_METHOD(addImageSync);
     static NAN_METHOD(addImageBuffer);
     static void EIO_AddImageBuffer(uv_work_t* req);
-    static void EIO_AfterAddImageBuffer(uv_work_t* req);
+    static void EIO_AfterAddImageBuffer(uv_work_t* req, int);
     static v8::Local<v8::Value> _addImageBufferSync(Nan::NAN_METHOD_ARGS_TYPE info);
     static NAN_METHOD(addImageBufferSync);
     static void EIO_RenderTile(uv_work_t* req);
-    static void EIO_AfterRenderTile(uv_work_t* req);
+    static void EIO_AfterRenderTile(uv_work_t* req, int);
     static NAN_METHOD(setData);
     static void EIO_SetData(uv_work_t* req);
-    static void EIO_AfterSetData(uv_work_t* req);
+    static void EIO_AfterSetData(uv_work_t* req, int);
     static v8::Local<v8::Value> _setDataSync(Nan::NAN_METHOD_ARGS_TYPE info);
     static NAN_METHOD(setDataSync);
     static NAN_METHOD(addData);
     static void EIO_AddData(uv_work_t* req);
-    static void EIO_AfterAddData(uv_work_t* req);
+    static void EIO_AfterAddData(uv_work_t* req, int);
     static v8::Local<v8::Value> _addDataSync(Nan::NAN_METHOD_ARGS_TYPE info);
     static NAN_METHOD(addDataSync);
     static NAN_METHOD(composite);
     static NAN_METHOD(compositeSync);
     static v8::Local<v8::Value> _compositeSync(Nan::NAN_METHOD_ARGS_TYPE info);
     static void EIO_Composite(uv_work_t* req);
-    static void EIO_AfterComposite(uv_work_t* req);
+    static void EIO_AfterComposite(uv_work_t* req, int);
     static NAN_METHOD(painted);
     static NAN_METHOD(clearSync);
     static v8::Local<v8::Value> _clearSync(Nan::NAN_METHOD_ARGS_TYPE info);
     static NAN_METHOD(clear);
     static void EIO_Clear(uv_work_t* req);
-    static void EIO_AfterClear(uv_work_t* req);
+    static void EIO_AfterClear(uv_work_t* req, int);
     static NAN_METHOD(empty);
     static NAN_METHOD(info);
 #if BOOST_VERSION >= 105800
     static NAN_METHOD(reportGeometrySimplicity);
     static void EIO_ReportGeometrySimplicity(uv_work_t* req);
-    static void EIO_AfterReportGeometrySimplicity(uv_work_t* req);
+    static void EIO_AfterReportGeometrySimplicity(uv_work_t* req, int);
     static NAN_METHOD(reportGeometrySimplicitySync);
     static v8::Local<v8::Value> _reportGeometrySimplicitySync(Nan::NAN_METHOD_ARGS_TYPE info);
     static NAN_METHOD(reportGeometryValidity);
     static void EIO_ReportGeometryValidity(uv_work_t* req);
-    static void EIO_AfterReportGeometryValidity(uv_work_t* req);
+    static void EIO_AfterReportGeometryValidity(uv_work_t* req, int);
     static NAN_METHOD(reportGeometryValiditySync);
     static v8::Local<v8::Value> _reportGeometryValiditySync(Nan::NAN_METHOD_ARGS_TYPE info);
 #endif // BOOST_VERSION >= 105800

--- a/src/mapnik_vector_tile.hpp
+++ b/src/mapnik_vector_tile.hpp
@@ -193,12 +193,12 @@ public:
     
     void _ref()
     { 
-        Ref(); 
+        Ref();
     }
     
     void _unref()
     { 
-        Unref(); 
+        Unref();
     }
 
 private:

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -14,6 +14,7 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wshadow"
+#pragma GCC diagnostic ignored "-Wcast-function-type"
 #include <nan.h>
 #pragma GCC diagnostic pop
 

--- a/test/feature.test.js
+++ b/test/feature.test.js
@@ -384,7 +384,7 @@ describe('mapnik.Feature ', function() {
                     coordinates: [[[1,1],[2,1],[2,2],[1,2],[1,1]]]
                 }
             };
-        var expected = new Buffer('01030000000100000005000000000000000000f03f000000000000f03f0000000000000040000000000000f03f00000000000000400000000000000040000000000000f03f0000000000000040000000000000f03f000000000000f03f', 'hex');
+        var expected = new Buffer.from('01030000000100000005000000000000000000f03f000000000000f03f0000000000000040000000000000f03f00000000000000400000000000000040000000000000f03f0000000000000040000000000000f03f000000000000f03f', 'hex');
         var ds = new mapnik.Datasource({type:'csv', 'inline': "geojson\n'" + JSON.stringify(feature.geometry) + "'"});
         var f = ds.featureset().next();
         assert.deepEqual(expected, f.geometry().toWKB());

--- a/test/geometry.test.js
+++ b/test/geometry.test.js
@@ -27,7 +27,7 @@ describe('mapnik.Geometry ', function() {
         var geom = f.geometry();
         assert.equal(geom.type(),mapnik.Geometry.MultiPoint);
         assert.deepEqual(JSON.parse(geom.toJSONSync()),point);
-        var expected_wkb = new Buffer('0104000000020000000101000000000000000000000000000000000000000101000000000000000000f03f000000000000f03f', 'hex');
+        var expected_wkb = new Buffer.from('0104000000020000000101000000000000000000000000000000000000000101000000000000000000f03f000000000000f03f', 'hex');
         assert.deepEqual(geom.toWKB(),expected_wkb);
     });
 

--- a/test/image.svg.test.js
+++ b/test/image.svg.test.js
@@ -24,7 +24,7 @@ describe('mapnik.Image SVG', function() {
           new mapnik.Image.fromSVGBytes({}, function(err, svg) {});
         }, /first argument is invalid, must be a Buffer/);
         assert.throws(function() {
-          new mapnik.Image.fromSVGBytesSync(new Buffer('asdfasdf'));
+          new mapnik.Image.fromSVGBytesSync(new Buffer.from('asdfasdf'));
         }, /SVG error: unable to parse "asdfasdf"/);
         assert.throws(function() {
           mapnik.Image.fromSVGSync('./test/data/SVG_DOES_NOT_EXIST.svg');
@@ -36,13 +36,13 @@ describe('mapnik.Image SVG', function() {
           mapnik.Image.fromSVG('./test/data/vector_tile/tile0.expected-svg.svg', 256);
         }, /last argument must be a callback function/);
         assert.throws(function() {
-          mapnik.Image.fromSVGBytes(new Buffer('asdfasdf'), 256);
+          mapnik.Image.fromSVGBytes(new Buffer.from('asdfasdf'), 256);
         }, /last argument must be a callback function/);
         assert.throws(function() {
           mapnik.Image.fromSVG('./test/data/vector_tile/tile0.expected-svg.svg', 256, function(err, res) {});
         }, /optional second arg must be an options object/);
         assert.throws(function() {
-          mapnik.Image.fromSVGBytes(new Buffer('asdfasdf'), 256, function(err, res) {});
+          mapnik.Image.fromSVGBytes(new Buffer.from('asdfasdf'), 256, function(err, res) {});
         }, /optional second arg must be an options object/);
         assert.throws(function() {
           mapnik.Image.fromSVGSync('./test/data/vector_tile/tile0.expected-svg.svg', { scale: 'foo' });
@@ -51,7 +51,7 @@ describe('mapnik.Image SVG', function() {
           mapnik.Image.fromSVG('./test/data/vector_tile/tile0.expected-svg.svg', { scale: 'foo' }, function(err, res) {});
         }, /'scale' must be a number/);
         assert.throws(function() {
-          mapnik.Image.fromSVGBytes(new Buffer('asdf'), { scale: 'foo' }, function(err, res) {});
+          mapnik.Image.fromSVGBytes(new Buffer.from('asdf'), { scale: 'foo' }, function(err, res) {});
         }, /'scale' must be a number/);
         assert.throws(function() {
           mapnik.Image.fromSVGBytes(undefined, { scale: 1 }, function(err, res) {});
@@ -66,21 +66,21 @@ describe('mapnik.Image SVG', function() {
           mapnik.Image.fromSVG('./test/data/vector_tile/tile0.expected-svg.svg', { scale: -1 }, function(err, res) {});
         }, /'scale' must be a positive non zero number/);
         assert.throws(function() {
-          mapnik.Image.fromSVGBytes(new Buffer('asdf'), { scale: -1 }, function(err, res) {});
+          mapnik.Image.fromSVGBytes(new Buffer.from('asdf'), { scale: -1 }, function(err, res) {});
         }, /'scale' must be a positive non zero number/);
         assert.throws(function() {
           mapnik.Image.fromSVGSync('./test/data/vector_tile/tile0.corrupt-svg.svg');
         }, /image created from svg must have a width and height greater then zero/);
-        mapnik.Image.fromSVGBytes(new Buffer('a'), { scale: 1 }, function(err, res) {
+        mapnik.Image.fromSVGBytes(new Buffer.from('a'), { scale: 1 }, function(err, res) {
             assert.ok(err);
             assert.ok(err.message.match(/SVG error: unable to parse "a"/));
             var svgdata = "<svg width='1000000000000' height='1000000000000'><g id='a'><ellipse fill='#FFFFFF' stroke='#000000' stroke-width='4' cx='50' cy='50' rx='25' ry='25'/></g></svg>";
-            var buffer = new Buffer(svgdata);
+            var buffer = new Buffer.from(svgdata);
             mapnik.Image.fromSVGBytes(buffer, { scale: 1 }, function(err, img) {
                 assert.ok(err);
                 assert.ok(err.message.match(/image created from svg must be 2048 pixels or fewer on each side/));
                 var svgdata2 = "<svg width='100' height='100'><g id='a'><ellipse fill='#FFFFFF' stroke='#000000' stroke-width='4' cx='50' cy='50' rx='25' ry='25'/></g></svg>";
-                var buffer2 = new Buffer(svgdata2);
+                var buffer2 = new Buffer.from(svgdata2);
                 mapnik.Image.fromSVGBytes(buffer2, { scale: 1000000 }, function(err, img) {
                     assert.ok(err);
                     assert.ok(err.message.match(/image created from svg must be 2048 pixels or fewer on each side/));
@@ -94,7 +94,7 @@ describe('mapnik.Image SVG', function() {
     it('blocks allocating a very large image', function(done) {
         // 65535 is the max width/height in mapnik
         var svgdata = "<svg width='65535' height='65535'><g id='a'><ellipse fill='#FFFFFF' stroke='#000000' stroke-width='4' cx='50' cy='50' rx='25' ry='25'/></g></svg>";
-        var buffer = new Buffer(svgdata);
+        var buffer = new Buffer.from(svgdata);
         mapnik.Image.fromSVGBytes(buffer, function(err, img) {
             assert.ok(err);
             assert.ok(err.message.match(/image created from svg must be 2048 pixels or fewer on each side/));
@@ -105,7 +105,7 @@ describe('mapnik.Image SVG', function() {
     it('customized the max image size to block', function(done) {
         // 65535 is the max width/height in mapnik
         var svgdata = "<svg width='65535' height='65535'><g id='a'><ellipse fill='#FFFFFF' stroke='#000000' stroke-width='4' cx='50' cy='50' rx='25' ry='25'/></g></svg>";
-        var buffer = new Buffer(svgdata);
+        var buffer = new Buffer.from(svgdata);
         mapnik.Image.fromSVGBytes(buffer, {max_size:2049}, function(err, img) {
             assert.ok(err);
             assert.ok(err.message.match(/image created from svg must be 2049 pixels or fewer on each side/));
@@ -116,7 +116,7 @@ describe('mapnik.Image SVG', function() {
     it('max image size blocks dimension*scale', function(done) {
         // 65535 is the max width/height in mapnik
         var svgdata = "<svg width='5000' height='5000'><g id='a'><ellipse fill='#FFFFFF' stroke='#000000' stroke-width='4' cx='50' cy='50' rx='25' ry='25'/></g></svg>";
-        var buffer = new Buffer(svgdata);
+        var buffer = new Buffer.from(svgdata);
         mapnik.Image.fromSVGBytes(buffer, {scale: 2, max_size:10000-1}, function(err, img) {
             assert.ok(err);
             assert.ok(err.message.match(/image created from svg must be 9999 pixels or fewer on each side/));
@@ -131,7 +131,7 @@ describe('mapnik.Image SVG', function() {
         it('allocates very large image', function(done) {
             // 65535 is the max width/height in mapnik
             var svgdata = "<svg width='5000' height='5000'><g id='a'><ellipse fill='#FFFFFF' stroke='#000000' stroke-width='4' cx='50' cy='50' rx='25' ry='25'/></g></svg>";
-            var buffer = new Buffer(svgdata);
+            var buffer = new Buffer.from(svgdata);
             mapnik.Image.fromSVGBytes(buffer, {scale: 2, max_size:10000}, function(err, img) {
                 if (err) throw err;
                 assert.equal(img.width(),10000);
@@ -152,7 +152,7 @@ describe('mapnik.Image SVG', function() {
 
     it('should err with async file w/o width or height as Bytes', function(done) {
         var svgdata = "<svg width='0' height='0'><g id='a'><ellipse fill='#FFFFFF' stroke='#000000' stroke-width='4' cx='50' cy='50' rx='25' ry='25'/></g></svg>";
-        var buffer = new Buffer(svgdata);
+        var buffer = new Buffer.from(svgdata);
         mapnik.Image.fromSVGBytes(buffer, function(err, img) {
             assert.ok(err);
             assert.ok(err.message.match(/image created from svg must have a width and height greater then zero/));
@@ -162,7 +162,7 @@ describe('mapnik.Image SVG', function() {
     });
 
     it('should err with async invalid buffer', function(done) {
-      mapnik.Image.fromSVGBytes(new Buffer('asdfasdf'), function(err, svg) {
+      mapnik.Image.fromSVGBytes(new Buffer.from('asdfasdf'), function(err, svg) {
         assert.ok(err);
         assert.ok(err.message.match(/SVG error: unable to parse "asdfasdf"/));
         assert.equal(svg, undefined);
@@ -209,7 +209,7 @@ describe('mapnik.Image SVG', function() {
 
     it('should not error on svg with unhandled elements in non-strict mode', function() {
         var svgdata = "<svg width='100' height='100'><g id='a'><text></text><ellipse fill='#FFFFFF' stroke='#000000' stroke-width='4' cx='50' cy='50' rx='25' ry='25'/></g></svg>";
-        var buffer = new Buffer(svgdata);
+        var buffer = new Buffer.from(svgdata);
         var img = mapnik.Image.fromSVGBytesSync(buffer,{strict:false});
         assert.ok(img);
         assert.ok(img instanceof mapnik.Image);
@@ -220,7 +220,7 @@ describe('mapnik.Image SVG', function() {
 
 
     function svg_error(svgdata) {
-            var buffer = new Buffer(svgdata);
+            var buffer = new Buffer.from(svgdata);
             var error = false;
             try {
                 var img = mapnik.Image.fromSVGBytesSync(buffer,{strict:true});
@@ -295,7 +295,7 @@ describe('mapnik.Image SVG', function() {
 
     it('#fromSVGBytesSync load from SVG buffer', function() {
         var svgdata = "<svg width='100' height='100'><g id='a'><ellipse fill='#FFFFFF' stroke='#000000' stroke-width='4' cx='50' cy='50' rx='25' ry='25'/></g></svg>";
-        var buffer = new Buffer(svgdata);
+        var buffer = new Buffer.from(svgdata);
         var img = mapnik.Image.fromSVGBytesSync(buffer);
         assert.ok(img);
         assert.ok(img instanceof mapnik.Image);
@@ -306,7 +306,7 @@ describe('mapnik.Image SVG', function() {
 
     it('#fromSVGBytesSync load from SVG buffer - 2', function() {
         var svgdata = "<svg width='100' height='100'><g id='a'><ellipse fill='#FFFFFF' stroke='#000000' stroke-width='4' cx='50' cy='50' rx='25' ry='25'/></g></svg>";
-        var buffer = new Buffer(svgdata);
+        var buffer = new Buffer.from(svgdata);
         var img = mapnik.Image.fromSVGBytes(buffer);
         assert.ok(img);
         assert.ok(img instanceof mapnik.Image);
@@ -317,7 +317,7 @@ describe('mapnik.Image SVG', function() {
 
     it('#fromSVGBytes load from SVG buffer', function(done) {
         var svgdata = "<svg width='100' height='100'><g id='a'><ellipse fill='#FFFFFF' stroke='#000000' stroke-width='4' cx='50' cy='50' rx='25' ry='25'/></g></svg>";
-        var buffer = new Buffer(svgdata);
+        var buffer = new Buffer.from(svgdata);
         mapnik.Image.fromSVGBytes(buffer, function(err, img) {
             assert.ok(img);
             assert.ok(img instanceof mapnik.Image);
@@ -331,7 +331,7 @@ describe('mapnik.Image SVG', function() {
 
     it('svg scaling', function() {
         var svgdata = "<svg width='100' height='100'><g id='a'><ellipse fill='#FFFFFF' stroke='#000000' stroke-width='4' cx='50' cy='50' rx='25' ry='25'/></g></svg>";
-        var buffer = new Buffer(svgdata);
+        var buffer = new Buffer.from(svgdata);
         var img = mapnik.Image.fromSVGBytesSync(buffer, { scale: 0.5});
         assert.ok(img);
         assert.ok(img instanceof mapnik.Image);

--- a/test/image.test.js
+++ b/test/image.test.js
@@ -63,7 +63,7 @@ describe('mapnik.Image ', function() {
 
     it('should encode with a pallete', function(done) {
         var im = new mapnik.Image(256, 256);
-        var pal = new mapnik.Palette(new Buffer('\xff\x09\x93\xFF\x01\x02\x03\x04','ascii'));
+        var pal = new mapnik.Palette(new Buffer.from('\xff\x09\x93\xFF\x01\x02\x03\x04','ascii'));
         assert.ok(im.encodeSync('png', {palette:pal}));
         im.encode('png', {palette:pal}, function(err, result) {
             if (err) throw err;
@@ -99,13 +99,13 @@ describe('mapnik.Image ', function() {
         assert.throws(function() { mapnik.Image.fromBytes({}); });
         assert.throws(function() { mapnik.Image.fromBytes({}, function(err, result) {}); });
         assert.throws(function() { mapnik.Image.fromBytesSync({}); });
-        assert.throws(function() { mapnik.Image.fromBytes(new Buffer(0)); });
-        assert.throws(function() { mapnik.Image.fromBytes(new Buffer(0),{premultiply:1},function(){}); });
-        assert.throws(function() { mapnik.Image.fromBytes(new Buffer(0), null); });
-        assert.throws(function() { mapnik.Image.fromBytesSync(new Buffer(1024)); });
-        var buffer = new Buffer('\x89\x50\x4E\x47\x0D\x0A\x1A\x0A' + new Array(48).join('\0'), 'binary');
+        assert.throws(function() { mapnik.Image.fromBytes(new Buffer.from(0)); });
+        assert.throws(function() { mapnik.Image.fromBytes(new Buffer.from(0),{premultiply:1},function(){}); });
+        assert.throws(function() { mapnik.Image.fromBytes(new Buffer.from(0), null); });
+        assert.throws(function() { mapnik.Image.fromBytesSync(new Buffer.from(1024)); });
+        var buffer = new Buffer.from('\x89\x50\x4E\x47\x0D\x0A\x1A\x0A' + new Array(48).join('\0'), 'binary');
         assert.throws(function() { mapnik.Image.fromBytesSync(buffer); });
-        buffer = new Buffer('\x89\x50\x4E\x47\x0D\x0A\x1A\x0A', 'binary');
+        buffer = new Buffer.from('\x89\x50\x4E\x47\x0D\x0A\x1A\x0A', 'binary');
         assert.throws(function() { mapnik.Image.fromBytesSync(buffer); });
         var stuff = mapnik.Image.fromBytes(buffer, function(err, result) {
             assert.throws(function() { if (err) throw err; });
@@ -1562,7 +1562,7 @@ describe('mapnik.Image ', function() {
     });
 
     it('should fail to use fromBufferSync due to bad input', function() {
-        var b = new Buffer(16);
+        var b = new Buffer.alloc(16);
         assert.throws(function() { var im = new mapnik.Image.fromBufferSync(); });
         assert.throws(function() { var im = new mapnik.Image.fromBufferSync(null, null, null); });
         assert.throws(function() { var im = new mapnik.Image.fromBufferSync(null, 2, b); });

--- a/test/image_view.test.js
+++ b/test/image_view.test.js
@@ -206,7 +206,7 @@ describe('mapnik.ImageView ', function() {
     it('should encode with a pallete', function(done) {
         var im = new mapnik.Image(256, 256);
         var view = im.view(0,0,256,256);
-        var pal = new mapnik.Palette(new Buffer('\xff\x09\x93\xFF\x01\x02\x03\x04','ascii'));
+        var pal = new mapnik.Palette(new Buffer.from('\xff\x09\x93\xFF\x01\x02\x03\x04','ascii'));
         assert.ok(view.encodeSync('png', {palette:pal}));
         view.encode('png', {palette:pal}, function(err, result) {
             if (err) throw err;
@@ -218,7 +218,7 @@ describe('mapnik.ImageView ', function() {
     it('should be able to save an ImageView', function(done) {
         var im = new mapnik.Image(256, 256);
         var view = im.view(0,0,256,256);
-        var pal = new mapnik.Palette(new Buffer('\xff\x09\x93\xFF\x01\x02\x03\x04','ascii'));
+        var pal = new mapnik.Palette(new Buffer.from('\xff\x09\x93\xFF\x01\x02\x03\x04','ascii'));
         var expected = './test/tmp/mapnik-image-view-saved.png';
         view.save(expected);
         assert.ok(fs.existsSync(expected));

--- a/test/palette.test.js
+++ b/test/palette.test.js
@@ -16,26 +16,26 @@ describe('mapnik.Palette ', function() {
         assert.throws(function() { new mapnik.Palette(); });
         assert.throws(function() { new mapnik.Palette(1); });
         assert.throws(function() { new mapnik.Palette('foo'); });
-        assert.throws(function() { new mapnik.Palette(new Buffer('\xff\x00\xff\xff\xff\xff','ascii'), 'bogus') });
+        assert.throws(function() { new mapnik.Palette(new Buffer.from('\xff\x00\xff\xff\xff\xff','ascii'), 'bogus') });
         assert.throws(function() {
-            new mapnik.Palette(new Buffer('\x01\x02\x03'));
+            new mapnik.Palette(new Buffer.from('\x01\x02\x03'));
         }, (/invalid palette length/));
     });
 
     it('should be initialized property', function() {
-        var pal = new mapnik.Palette(new Buffer('\x01\x02\x03\x04','ascii'));
+        var pal = new mapnik.Palette(new Buffer.from('\x01\x02\x03\x04','ascii'));
         assert.equal('[Palette 1 color #01020304]', pal.toString());
 
-        pal = new mapnik.Palette(new Buffer('\x01\x02\x03','ascii'), 'rgb');
+        pal = new mapnik.Palette(new Buffer.from('\x01\x02\x03','ascii'), 'rgb');
         assert.equal('[Palette 1 color #010203]', pal.toString());
 
-        pal = new mapnik.Palette(new Buffer('\xff\x09\x93\xFF\x01\x02\x03\x04','ascii'), 'rgba');
+        pal = new mapnik.Palette(new Buffer.from('\xff\x09\x93\xFF\x01\x02\x03\x04','ascii'), 'rgba');
         assert.equal('[Palette 2 colors #01020304 #ff0993]', pal.toString());
-        assert.equal(new Buffer('\x01\x02\x03\x04\xff\x09\x93\xFF'), pal.toBuffer().toString('binary'));
+        assert.equal(new Buffer.from('\x01\x02\x03\x04\xff\x09\x93\xFF'), pal.toBuffer().toString('binary'));
         
-        pal = new mapnik.Palette(new Buffer('\xff\x09\x93\xFF\x01\x02\x03\x04','ascii'));
+        pal = new mapnik.Palette(new Buffer.from('\xff\x09\x93\xFF\x01\x02\x03\x04','ascii'));
         assert.equal('[Palette 2 colors #01020304 #ff0993]', pal.toString());
-        assert.equal(new Buffer('\x01\x02\x03\x04\xff\x09\x93\xFF'), pal.toBuffer().toString('binary'));
+        assert.equal(new Buffer.from('\x01\x02\x03\x04\xff\x09\x93\xFF'), pal.toBuffer().toString('binary'));
     });
 
     it('should support 64 color ACT palettes', function() {
@@ -53,7 +53,7 @@ describe('mapnik.Palette ', function() {
         map.fromStringSync(fs.readFileSync('./test/stylesheet.xml', 'utf8'), { strict: true, base: './test/' });
         map.zoomAll();
 
-        var pal = new mapnik.Palette(new Buffer('\xff\x00\xff\xff\xff\xff','ascii'), 'rgb');
+        var pal = new mapnik.Palette(new Buffer.from('\xff\x00\xff\xff\xff\xff','ascii'), 'rgb');
 
         // Test rendering a blank image
         var filename = helper.filename();
@@ -69,7 +69,7 @@ describe('mapnik.Palette ', function() {
         map.fromStringSync(fs.readFileSync('./test/stylesheet.xml', 'utf8'), { strict: true, base: './test/' });
         map.zoomAll();
 
-        var pal = new mapnik.Palette(new Buffer('\xff\x00\xff\xff\xff\xff','ascii'), 'rgb');
+        var pal = new mapnik.Palette(new Buffer.from('\xff\x00\xff\xff\xff\xff','ascii'), 'rgb');
 
         // Test rendering a blank image
         var filename = helper.filename();

--- a/test/vector-tile.test.js
+++ b/test/vector-tile.test.js
@@ -962,13 +962,13 @@ describe('mapnik.VectorTile ', function() {
             var buffer;
             switch (buffers.length) {
                 case 0: // no data.  return empty buffer
-                    buffer = new Buffer(0);
+                    buffer = new Buffer.alloc(0);
                     break;
                 case 1: // only one chunk of data.  return it.
                     buffer = buffers[0];
                     break;
                 default: // concatenate the chunks of data into a single buffer.
-                    buffer = new Buffer(nread);
+                    buffer = new Buffer.alloc(nread);
                     var n = 0;
                     buffers.forEach(function(b) {
                         var l = b.length;
@@ -1017,13 +1017,13 @@ describe('mapnik.VectorTile ', function() {
             var buffer;
             switch (buffers.length) {
                 case 0: // no data.  return empty buffer
-                    buffer = new Buffer(0);
+                    buffer = new Buffer.alloc(0);
                     break;
                 case 1: // only one chunk of data.  return it.
                     buffer = buffers[0];
                     break;
                 default: // concatenate the chunks of data into a single buffer.
-                    buffer = new Buffer(nread);
+                    buffer = new Buffer.alloc(nread);
                     var n = 0;
                     buffers.forEach(function(b) {
                         var l = b.length;
@@ -1072,13 +1072,13 @@ describe('mapnik.VectorTile ', function() {
             var buffer;
             switch (buffers.length) {
                 case 0: // no data.  return empty buffer
-                    buffer = new Buffer(0);
+                    buffer = new Buffer.alloc(0);
                     break;
                 case 1: // only one chunk of data.  return it.
                     buffer = buffers[0];
                     break;
                 default: // concatenate the chunks of data into a single buffer.
-                    buffer = new Buffer(nread);
+                    buffer = new Buffer.alloc(nread);
                     var n = 0;
                     buffers.forEach(function(b) {
                         var l = b.length;
@@ -1127,13 +1127,13 @@ describe('mapnik.VectorTile ', function() {
             var buffer;
             switch (buffers.length) {
                 case 0: // no data.  return empty buffer
-                    buffer = new Buffer(0);
+                    buffer = new Buffer.alloc(0);
                     break;
                 case 1: // only one chunk of data.  return it.
                     buffer = buffers[0];
                     break;
                 default: // concatenate the chunks of data into a single buffer.
-                    buffer = new Buffer(nread);
+                    buffer = new Buffer.alloc(nread);
                     var n = 0;
                     buffers.forEach(function(b) {
                         var l = b.length;
@@ -1182,13 +1182,13 @@ describe('mapnik.VectorTile ', function() {
             var buffer;
             switch (buffers.length) {
                 case 0: // no data.  return empty buffer
-                    buffer = new Buffer(0);
+                    buffer = new Buffer.alloc(0);
                     break;
                 case 1: // only one chunk of data.  return it.
                     buffer = buffers[0];
                     break;
                 default: // concatenate the chunks of data into a single buffer.
-                    buffer = new Buffer(nread);
+                    buffer = new Buffer.alloc(nread);
                     var n = 0;
                     buffers.forEach(function(b) {
                         var l = b.length;
@@ -1245,7 +1245,7 @@ describe('mapnik.VectorTile ', function() {
 
     it('setData should error on bogus gzip data', function(done) {
         var vtile = new mapnik.VectorTile(0,0,0);
-        var fake_gzip = new Buffer(30);
+        var fake_gzip = new Buffer.alloc(30);
         fake_gzip.fill(0);
         fake_gzip[0] = 0x1F;
         fake_gzip[1] = 0x8B;
@@ -1258,7 +1258,7 @@ describe('mapnik.VectorTile ', function() {
 
     it('setData should error on bogus zlib data', function(done) {
         var vtile = new mapnik.VectorTile(0,0,0);
-        var fake_zlib = new Buffer(30);
+        var fake_zlib = new Buffer.alloc(30);
         fake_zlib.fill(0);
         fake_zlib[0] = 0x78;
         fake_zlib[1] = 0x9C;
@@ -1276,7 +1276,7 @@ describe('mapnik.VectorTile ', function() {
     });
 
     it('info should show error on bogus gzip data', function() {
-        var fake_gzip = new Buffer(30);
+        var fake_gzip = new Buffer.alloc(30);
         fake_gzip.fill(0);
         fake_gzip[0] = 0x1F;
         fake_gzip[1] = 0x8B;
@@ -1288,7 +1288,7 @@ describe('mapnik.VectorTile ', function() {
     });
 
     it('info should show error on bogus zlib data', function() {
-        var fake_zlib = new Buffer(30);
+        var fake_zlib = new Buffer.alloc(30);
         fake_zlib.fill(0);
         fake_zlib[0] = 0x78;
         fake_zlib[1] = 0x9C;
@@ -1341,9 +1341,9 @@ describe('mapnik.VectorTile ', function() {
         assert.throws(function() { vtile.setData('foo',function(){}); }); // first arg must be a buffer object
         assert.throws(function() { vtile.setData({},function(){}); }); // first arg must be a buffer object
         assert.throws(function() { vtile.setData({},function(){}); }); // first arg must be a buffer object
-        assert.throws(function() { vtile.setData(new Buffer('foo'), null); });
-        assert.throws(function() { vtile.setData(new Buffer(0)); }); // empty buffer is not valid
-        vtile.setData(new Buffer('foo'),function(err) {
+        assert.throws(function() { vtile.setData(new Buffer.from('foo'), null); });
+        assert.throws(function() { vtile.setData(new Buffer.alloc(0)); }); // empty buffer is not valid
+        vtile.setData(new Buffer.from('foo'),function(err) {
             assert.throws(function() { if (err) throw err; });
             done();
         });
@@ -1366,7 +1366,7 @@ describe('mapnik.VectorTile ', function() {
     it('should error out if we pass invalid data to setData - 2', function(done) {
         var vtile = new mapnik.VectorTile(0,0,0);
         assert.equal(vtile.empty(), true);
-        vtile.setData(new Buffer('0'),function(err) {
+        vtile.setData(new Buffer.from('0'),function(err) {
             assert.throws(function() { if (err) throw err; });
             done();
         });
@@ -1375,7 +1375,7 @@ describe('mapnik.VectorTile ', function() {
     it('should error out if we pass invalid data to setData - 3', function(done) {
         var vtile = new mapnik.VectorTile(0,0,0);
         assert.equal(vtile.empty(), true);
-        vtile.setData(new Buffer('0B1234', 'hex'),function(err) {
+        vtile.setData(new Buffer.from('0B1234', 'hex'),function(err) {
             assert.throws(function() { if (err) throw err; });
             done();
         });
@@ -1385,28 +1385,28 @@ describe('mapnik.VectorTile ', function() {
         var vtile = new mapnik.VectorTile(0,0,0);
         assert.equal(vtile.empty(), true);
         // fails due to invalid tag
-        assert.throws(function() { vtile.setData(new Buffer('120774657374696e67', 'hex')); });
+        assert.throws(function() { vtile.setData(new Buffer.from('120774657374696e67', 'hex')); });
         assert.equal(vtile.empty(), true);
         // fails due to invalid tag
-        assert.throws(function() { vtile.setData(new Buffer('089601', 'hex')); });
+        assert.throws(function() { vtile.setData(new Buffer.from('089601', 'hex')); });
         assert.equal(vtile.empty(), true);
         assert.throws(function() {
-            vtile.setData(new Buffer('0896818181818181818181818181818181818181', 'hex'));
+            vtile.setData(new Buffer.from('0896818181818181818181818181818181818181', 'hex'));
         });
         assert.throws(function() {
-            vtile.setData(new Buffer('0896818181818181818181818181818181818181', 'hex'));
+            vtile.setData(new Buffer.from('0896818181818181818181818181818181818181', 'hex'));
         });
         assert.throws(function() {
-            vtile.setData(new Buffer('090123456789012345', 'hex'));
+            vtile.setData(new Buffer.from('090123456789012345', 'hex'));
         });
         assert.throws(function() {
-            vtile.setData(new Buffer('0D01234567', 'hex'));
+            vtile.setData(new Buffer.from('0D01234567', 'hex'));
         });
         assert.throws(function() {
-            vtile.setData(new Buffer('0D0123456', 'hex')); // 32 should fail because missing a byte
+            vtile.setData(new Buffer.from('0D0123456', 'hex')); // 32 should fail because missing a byte
         });
         assert.throws(function() {
-            vtile.setData(new Buffer('0D0123456', 'hex')); // 32 should fail because missing a byte
+            vtile.setData(new Buffer.from('0D0123456', 'hex')); // 32 should fail because missing a byte
         });
     });
 
@@ -1414,7 +1414,7 @@ describe('mapnik.VectorTile ', function() {
         var vtile = new mapnik.VectorTile(0,0,0);
         assert.equal(vtile.empty(), true);
         assert.equal(vtile.empty(), true);
-        vtile.setData(new Buffer(0),function(err) {
+        vtile.setData(new Buffer.alloc(0),function(err) {
             assert.throws(function() { if (err) throw err; });
             assert.deepEqual(vtile.names(), []);
             assert.equal(vtile.empty(), true);
@@ -1424,14 +1424,14 @@ describe('mapnik.VectorTile ', function() {
 
     it('should not return empty and will have layer name', function() {
         var vtile = new mapnik.VectorTile(0,0,0);
-        vtile.setData(new Buffer('1A0C0A0A6C617965722D6E616D65', 'hex'));
+        vtile.setData(new Buffer.from('1A0C0A0A6C617965722D6E616D65', 'hex'));
         assert.deepEqual(vtile.names(), ['layer-name']);
         assert.equal(vtile.empty(), false);
     });
 
     it('should return empty and have no layer name when upgraded', function() {
         var vtile = new mapnik.VectorTile(0,0,0);
-        vtile.setData(new Buffer('1A0C0A0A6C617965722D6E616D65', 'hex'),{upgrade:true});
+        vtile.setData(new Buffer.from('1A0C0A0A6C617965722D6E616D65', 'hex'),{upgrade:true});
         // a layer with only a name "layer-name" and no features
         // during v1 to v2 conversion this will be dropped
         // note: this tile also lacks a version, but mapnik-vt defaults to assuming v1
@@ -1444,19 +1444,19 @@ describe('mapnik.VectorTile ', function() {
         assert.equal(vtile.empty(), true);
         assert.throws(function() { vtile.addData(null); }); // empty buffer is not valid
         assert.throws(function() { vtile.addData({}); }); // empty buffer is not valid
-        assert.throws(function() { vtile.addData(new Buffer(0)); }); // empty buffer is not valid
-        assert.throws(function() { vtile.addData(new Buffer('foo')); });
-        assert.throws(function() { vtile.addData(new Buffer(0), 'not a function'); }); // last item must be a function
+        assert.throws(function() { vtile.addData(new Buffer.alloc(0)); }); // empty buffer is not valid
+        assert.throws(function() { vtile.addData(new Buffer.from('foo')); });
+        assert.throws(function() { vtile.addData(new Buffer.alloc(0), 'not a function'); }); // last item must be a function
         assert.throws(function() { vtile.addDataSync(null); }); // empty buffer is not valid
         assert.throws(function() { vtile.addDataSync({}); }); // empty buffer is not valid
-        assert.throws(function() { vtile.addDataSync(new Buffer(0)); }); // empty buffer is not valid
-        assert.throws(function() { vtile.addDataSync(new Buffer('foo')); });
+        assert.throws(function() { vtile.addDataSync(new Buffer.alloc(0)); }); // empty buffer is not valid
+        assert.throws(function() { vtile.addDataSync(new Buffer.from('foo')); });
         assert.throws(function() { vtile.addData(null, function(err) {}); });
         assert.throws(function() { vtile.addData({}, function(err) {}); });
 
-        vtile.addData(new Buffer(0), function(err) {
+        vtile.addData(new Buffer.alloc(0), function(err) {
             assert.throws(function() { if (err) throw err; });
-            vtile.addData(new Buffer('foo'), function(err) {
+            vtile.addData(new Buffer.from('foo'), function(err) {
                 assert.throws(function() { if (err) throw err; });
                 done();
             });
@@ -1468,17 +1468,17 @@ describe('mapnik.VectorTile ', function() {
         assert.equal(vtile.empty(), true);
         assert.throws(function() { vtile.setData(null); }); // empty buffer is not valid
         assert.throws(function() { vtile.setData({}); }); // empty buffer is not valid
-        assert.throws(function() { vtile.setData(new Buffer(0)); }); // empty buffer is not valid
-        assert.throws(function() { vtile.setData(new Buffer('foo')); });
+        assert.throws(function() { vtile.setData(new Buffer.alloc(0)); }); // empty buffer is not valid
+        assert.throws(function() { vtile.setData(new Buffer.from('foo')); });
         assert.throws(function() { vtile.setDataSync(null); }); // empty buffer is not valid
         assert.throws(function() { vtile.setDataSync({}); }); // empty buffer is not valid
-        assert.throws(function() { vtile.setDataSync(new Buffer(0)); }); // empty buffer is not valid
-        assert.throws(function() { vtile.setDataSync(new Buffer('foo')); });
+        assert.throws(function() { vtile.setDataSync(new Buffer.alloc(0)); }); // empty buffer is not valid
+        assert.throws(function() { vtile.setDataSync(new Buffer.from('foo')); });
         assert.throws(function() { vtile.setData(null, function(err) {}); });
         assert.throws(function() { vtile.setData({}, function(err) {}); });
-        vtile.setData(new Buffer(0), function(err) {
+        vtile.setData(new Buffer.alloc(0), function(err) {
             assert.throws(function() { if (err) throw err; });
-            vtile.setData(new Buffer('foo'), function(err) {
+            vtile.setData(new Buffer.from('foo'), function(err) {
                 assert.throws(function() { if (err) throw err; });
                 done();
             });
@@ -1492,8 +1492,8 @@ describe('mapnik.VectorTile ', function() {
 
     it('should fail to addData/setData due to bad data', function() {
         var vtile = new mapnik.VectorTile(0,0,0);
-        assert.throws(function() { vtile.addData(new Buffer('foo')); });
-        assert.throws(function() { vtile.setData(new Buffer('foo')); });
+        assert.throws(function() { vtile.addData(new Buffer.from('foo')); });
+        assert.throws(function() { vtile.setData(new Buffer.from('foo')); });
     });
 
     it('should be able to addData sync', function() {
@@ -1608,7 +1608,7 @@ describe('mapnik.VectorTile ', function() {
 
     it('should be able to get tile info as JSON', function(done) {
         var vtile = new mapnik.VectorTile(9,112,195);
-        vtile.setData(new Buffer(_data,"hex"));
+        vtile.setData(new Buffer.from(_data,"hex"));
         assert.deepEqual(vtile.names(),['world','world2']);
         var expected = [
             {
@@ -1668,7 +1668,7 @@ describe('mapnik.VectorTile ', function() {
 
     it('should be able to get tile info as JSON with decoded geometry', function(done) {
         var vtile = new mapnik.VectorTile(9,112,195);
-        vtile.setData(new Buffer(_data,"hex"));
+        vtile.setData(new Buffer.from(_data,"hex"));
         assert.deepEqual(vtile.names(),['world','world2']);
         var expected = [
             {
@@ -1734,7 +1734,7 @@ describe('mapnik.VectorTile ', function() {
 
     it('should be able to get tile info as various flavors of GeoJSON', function(done) {
         var vtile = new mapnik.VectorTile(9,112,195);
-        vtile.setData(new Buffer(_data,"hex"));
+        vtile.setData(new Buffer.from(_data,"hex"));
         var expected_geojson = {
             "type":"FeatureCollection",
             "features":[
@@ -1810,7 +1810,7 @@ describe('mapnik.VectorTile ', function() {
 
     it('should be able to get and set data (sync)', function(done) {
         var vtile = new mapnik.VectorTile(9,112,195);
-        vtile.setData(new Buffer(_data,"hex"));
+        vtile.setData(new Buffer.from(_data,"hex"));
         var vtile2 = new mapnik.VectorTile(9,112,195);
         vtile2.setData(vtile.getData());
         assert.deepEqual(vtile.names(),vtile2.names());
@@ -1821,7 +1821,7 @@ describe('mapnik.VectorTile ', function() {
 
     it('should be able to get and set data (async)', function(done) {
         var vtile = new mapnik.VectorTile(9,112,195);
-        vtile.setData(new Buffer(_data,"hex"),function(err) {
+        vtile.setData(new Buffer.from(_data,"hex"),function(err) {
             if (err) throw err;
             var vtile2 = new mapnik.VectorTile(9,112,195);
             vtile.getData(function(err,data) {
@@ -1837,7 +1837,7 @@ describe('mapnik.VectorTile ', function() {
 
     it('should be able to get virtual datasource and features', function(done) {
         var vtile = new mapnik.VectorTile(9,112,195);
-        vtile.setData(new Buffer(_data,"hex"));
+        vtile.setData(new Buffer.from(_data,"hex"));
         assert.equal(vtile.getData().length,_length);
         var ds = vtile.toJSON();
         assert.equal(ds.length,2);
@@ -1882,7 +1882,7 @@ describe('mapnik.VectorTile ', function() {
 
     it('should be able to clear data (sync)', function(done) {
         var vtile = new mapnik.VectorTile(9,112,195);
-        vtile.setData(new Buffer(_data,"hex"));
+        vtile.setData(new Buffer.from(_data,"hex"));
         assert.equal(vtile.getData().length,_length);
         assert.equal(vtile.painted(), true);
         var feature_count = vtile.toJSON()[0].features.length;
@@ -1895,7 +1895,7 @@ describe('mapnik.VectorTile ', function() {
 
         // call synchronous method directly
         var vtile2 = new mapnik.VectorTile(9,112,195);
-        vtile2.setData(new Buffer(_data,"hex"));
+        vtile2.setData(new Buffer.from(_data,"hex"));
         assert.equal(vtile2.getData().length,_length);
         assert.equal(vtile2.painted(), true);
         var feature_count2 = vtile2.toJSON()[0].features.length;
@@ -1910,7 +1910,7 @@ describe('mapnik.VectorTile ', function() {
 
     it('should be able to clear data (async)', function(done) {
         var vtile = new mapnik.VectorTile(9,112,195);
-        vtile.setData(new Buffer(_data,"hex"));
+        vtile.setData(new Buffer.from(_data,"hex"));
         assert.equal(vtile.empty(), false);
         assert.deepEqual(vtile.names(), ["world","world2"]);
         assert.equal(vtile.empty(), false);
@@ -1933,17 +1933,17 @@ describe('mapnik.VectorTile ', function() {
 
     it('should be able to add data', function(done) {
         var vtile = new mapnik.VectorTile(9,112,195);
-        vtile.setData(new Buffer(_data,"hex"));
+        vtile.setData(new Buffer.from(_data,"hex"));
         assert.equal(vtile.empty(), false);
         assert.equal(vtile.painted(), true);
         assert.deepEqual(vtile.names(), ["world","world2"]);
         // Setting data again should still result in the same data.
-        vtile.setData(new Buffer(_data,"hex"));
+        vtile.setData(new Buffer.from(_data,"hex"));
         assert.equal(vtile.empty(), false);
         assert.equal(vtile.painted(), true);
         assert.deepEqual(vtile.names(), ["world","world2"]);
         // Adding same data again should not result in new data.
-        vtile.addData(new Buffer(_data,"hex"));
+        vtile.addData(new Buffer.from(_data,"hex"));
         assert.equal(vtile.empty(), false);
         assert.deepEqual(vtile.names(), ["world","world2"]);
         assert.equal(vtile.getData().length,_length);
@@ -2856,21 +2856,21 @@ describe('mapnik.VectorTile ', function() {
         assert.throws(function() { vtile.addImageBuffer(null); });
         assert.throws(function() { vtile.addImageBuffer('asdf'); });
         assert.throws(function() { vtile.addImageBuffer({}); });
-        assert.throws(function() { vtile.addImageBuffer(new Buffer('foo')); });
-        assert.throws(function() { vtile.addImageBuffer(new Buffer('foo'), 12); });
+        assert.throws(function() { vtile.addImageBuffer(new Buffer.from('foo')); });
+        assert.throws(function() { vtile.addImageBuffer(new Buffer.from('foo'), 12); });
         assert.throws(function() { vtile.addImageBuffer({}, 'asdf'); });
-        assert.throws(function() { vtile.addImageBuffer(new Buffer(0), 'waka', {}); });
+        assert.throws(function() { vtile.addImageBuffer(new Buffer.alloc(0), 'waka', {}); });
         assert.throws(function() { vtile.addImageBuffer({}, 'asdf', function(err) {}); });
         assert.throws(function() { vtile.addImageBuffer({}, 'asdf', function(err) {}); });
-        assert.throws(function() { vtile.addImageBuffer(new Buffer('foo'), 12, function(err) {}); });
+        assert.throws(function() { vtile.addImageBuffer(new Buffer.from('foo'), 12, function(err) {}); });
         assert.throws(function() { vtile.addImageBuffer('not a buffer', 'bar', function(err) {}); });
         assert.throws(function() { vtile.addImageBufferSync(); });
         assert.throws(function() { vtile.addImageBufferSync(null); });
         assert.throws(function() { vtile.addImageBufferSync('asdf'); });
         assert.throws(function() { vtile.addImageBufferSync({}); });
-        assert.throws(function() { vtile.addImageBufferSync(new Buffer(0), 'waka'); });
-        assert.throws(function() { vtile.addImageBufferSync(new Buffer('foo')); });
-        assert.throws(function() { vtile.addImageBufferSync(new Buffer('foo'), 12); });
+        assert.throws(function() { vtile.addImageBufferSync(new Buffer.alloc(0), 'waka'); });
+        assert.throws(function() { vtile.addImageBufferSync(new Buffer.from('foo')); });
+        assert.throws(function() { vtile.addImageBufferSync(new Buffer.from('foo'), 12); });
         assert.throws(function() { vtile.addImageBufferSync({}, 'asdf', function(err) {}); });
         assert.throws(function() { vtile.addImageBufferSync({}, 'asdf', function(err) {}); });
         done();


### PR DESCRIPTION
 - Silence GCC warnings around uv_after_work_cb functions.
 - Tests: Avoid Buffer() constructor.
 - Avoid dangling references when an error happenned before an async task

The current node 12 failure is due to a bug in 12.3.0 (https://github.com/nodejs/node/issues/27803)